### PR TITLE
Fix recommendation sourceIDs being reset on each add

### DIFF
--- a/Worm/Sources/Screens/Recommendations/RecommendationsModel.swift
+++ b/Worm/Sources/Screens/Recommendations/RecommendationsModel.swift
@@ -141,13 +141,6 @@ actor RecommendationsDefaultModel: RecommendationsModel {
     }
 
     private func addRecommendedBook(withID id: String, for sourceID: String) async {
-        if let bookDescriptor = prioritizedRecommendations[id] {
-            var sourceIDs = bookDescriptor.sourceIDs
-            sourceIDs.insert(sourceID)
-
-            prioritizedRecommendations[id] = (bookDescriptor.book, sourceIDs)
-        }
-
         guard let book = await catalogService.getBook(by: id) else {
             return
         }
@@ -156,7 +149,10 @@ actor RecommendationsDefaultModel: RecommendationsModel {
         if await favoritesService.blockedBookIDs.contains(id) {
             prioritizedRecommendations.removeValue(forKey: id)
         } else {
-            prioritizedRecommendations[id] = (book, [sourceID])
+            var sourceIDs = prioritizedRecommendations[id]?.sourceIDs ?? []
+            sourceIDs.insert(sourceID)
+
+            prioritizedRecommendations[id] = (book, sourceIDs)
         }
     }
 

--- a/WormTests/Tests/Screens/Recommendations/RecommendationsDefaultModelTests.swift
+++ b/WormTests/Tests/Screens/Recommendations/RecommendationsDefaultModelTests.swift
@@ -169,6 +169,47 @@ struct RecommendationsDefaultModelTests {
     }
 
     @Test(.timeLimit(.minutes(1)))
+    func recommendationsUpdate_keepsBook_whenOnlyOneOfMultipleSourcesIsRemoved() async {
+        let firstFavorite = Book(
+            id: "1", authors: ["Author"], title: "First Favorite", description: "Desc1", similarBookIDs: ["100"]
+        )
+        let secondFavorite = Book(
+            id: "2", authors: ["Author"], title: "Second Favorite", description: "Desc2", similarBookIDs: ["100"]
+        )
+
+        let recommendedBook = Book(
+            id: "100", authors: ["Author"], title: "Recommended", description: "Desc3", similarBookIDs: []
+        )
+
+        let model: RecommendationsModel = await RecommendationsDefaultModel(
+            catalogService: CatalogMockService(
+                books: [
+                    firstFavorite,
+                    secondFavorite,
+                    recommendedBook
+                ]
+            ),
+            favoritesService: FavoritesMockService(
+                favoriteBookIDs: [
+                    firstFavorite.id,
+                    secondFavorite.id
+                ]
+            )
+        )
+
+        var books = await model.recommendationsPublisher.dropFirst().values.makeAsyncIterator()
+        await #expect(books.next() == [recommendedBook], "Unexpected data received.")
+
+        try? await Task.sleep(for: .seconds(1)) // Lets both favorite sources finish adding the recommendation.
+
+        await model.toggleFavoriteStateOfBook(withID: secondFavorite.id)
+        await #expect(
+            books.next() == [recommendedBook],
+            "The book should stay recommended while the other favorite still recommends it."
+        )
+    }
+
+    @Test(.timeLimit(.minutes(1)))
     func recommendationsUpdate_received_onBlockingRecommendation() async {
         let book = Book(
             id: "1",


### PR DESCRIPTION
## Summary
- `addRecommendedBook` merged a book's `sourceIDs` into the existing entry, then immediately overwrote it with a single-element set, resetting the relevance count every time.
- The core "recommendations shown in order of relevance" feature was silently defeated: equal-count books were never distinguished, and unfavoriting one of several favorites that recommended the same book could drop it entirely even while other favorites still recommended it.

## Fix
- The merge now happens once, right before the final write, reading whatever is currently in `prioritizedRecommendations[id]` — including any concurrent updates that happened while awaiting the book fetch.

## Test plan
- [x] Added `recommendationsUpdate_keepsBook_whenOnlyOneOfMultipleSourcesIsRemoved`: two favorites recommend the same book; unfavoriting one should leave the book recommended since the other still recommends it.
- [x] Verified the new test fails against the original code (reverted the fix, confirmed the book was incorrectly dropped) and passes with the fix.
- [x] Full suite: 88/88 passing.