### PR TITLE
Preserve relevance order for recommendations and search results

### DIFF
--- a/Worm/Sources/Screens/Recommendations/RecommendationsModel.swift
+++ b/Worm/Sources/Screens/Recommendations/RecommendationsModel.swift
@@ -22,9 +22,9 @@ protocol RecommendationsModel: Actor {
     /// The publisher of changes to the list of favorite book IDs.
     var favoriteBookIDsPublisher: Published<Set<String>>.Publisher { get }
     /// A list of recommended books in ready-to-display order.
-    var recommendations: Set<Book> { get }
+    var recommendations: [Book] { get }
     /// The publisher of changes to the list of recommended books.
-    var recommendationsPublisher: Published<Set<Book>>.Publisher { get }
+    var recommendationsPublisher: Published<[Book]>.Publisher { get }
 
     // MARK: - Methods
 
@@ -47,11 +47,11 @@ actor RecommendationsDefaultModel: RecommendationsModel {
     // MARK: RecommendationsModel protocol properties
 
     var favoriteBookIDsPublisher: Published<Set<String>>.Publisher { $favoriteBookIDs }
-    var recommendationsPublisher: Published<Set<Book>>.Publisher { $recommendations }
+    var recommendationsPublisher: Published<[Book]>.Publisher { $recommendations }
     @Published
     private(set) var favoriteBookIDs = Set<String>()
     @Published
-    private(set) var recommendations = Set<Book>()
+    private(set) var recommendations = [Book]()
 
     // MARK: Private properties
 
@@ -60,12 +60,10 @@ actor RecommendationsDefaultModel: RecommendationsModel {
     private lazy var cancellables = Set<AnyCancellable>()
     private var prioritizedRecommendations = OrderedDictionary<String, (book: Book, sourceIDs: Set<String>)>() {
         didSet {
-            recommendations = Set(
-                prioritizedRecommendations
-                    .values
-                    .stableSorted { $0.sourceIDs.count > $1.sourceIDs.count }
-                    .compactMap { $0.book }
-            )
+            recommendations = prioritizedRecommendations
+                .values
+                .stableSorted { $0.sourceIDs.count > $1.sourceIDs.count }
+                .map { $0.book }
         }
     }
 

--- a/Worm/Sources/Screens/Search/SearchModel.swift
+++ b/Worm/Sources/Screens/Search/SearchModel.swift
@@ -14,10 +14,10 @@ protocol SearchModel: Actor {
 
     // MARK: - Properties
 
-    /// The list of books corresponding to the current search query.
-    var books: Set<Book> { get }
+    /// The list of books corresponding to the current search query, in relevance order.
+    var books: [Book] { get }
     /// The publisher of changes to the list of books corresponding to the current search query.
-    var booksPublisher: Published<Set<Book>>.Publisher { get }
+    var booksPublisher: Published<[Book]>.Publisher { get }
     /// The list of favorite book IDs.
     var favoriteBookIDs: Set<String> { get }
     /// The publisher of books to the list of favorite book IDs.
@@ -43,10 +43,10 @@ actor SearchServiceBasedModel: SearchModel {
 
     // MARK: SearchModel protocol properties
 
-    var booksPublisher: Published<Set<Book>>.Publisher { $books }
+    var booksPublisher: Published<[Book]>.Publisher { $books }
     var favoriteBookIDsPublisher: Published<Set<String>>.Publisher { $favoriteBookIDs }
     @Published
-    private(set) var books = Set<Book>()
+    private(set) var books = [Book]()
     @Published
     private(set) var favoriteBookIDs = Set<String>()
 
@@ -64,6 +64,7 @@ actor SearchServiceBasedModel: SearchModel {
         }
     }
     private var currentSearchTask: Task<(), Error>?
+    private var fetchedBooks = [String : Book]()
 
     // MARK: - Initialization
 
@@ -99,6 +100,7 @@ actor SearchServiceBasedModel: SearchModel {
             }
 
             books.removeAll()
+            fetchedBooks.removeAll()
             currentSearchResult.removeAll()
 
             if !query.isEmpty {
@@ -140,9 +142,12 @@ actor SearchServiceBasedModel: SearchModel {
     }
 
     private func appendIfNeeded(book: Book) {
-        if currentSearchResult.contains(book.id) {
-            books.insert(book)
+        guard currentSearchResult.contains(book.id) else {
+            return
         }
+
+        fetchedBooks[book.id] = book
+        books = currentSearchResult.compactMap { fetchedBooks[$0] }
     }
 
 }

--- a/WormTests/Mocks/CatalogMockService.swift
+++ b/WormTests/Mocks/CatalogMockService.swift
@@ -16,13 +16,15 @@ final class CatalogMockService: CatalogService {
     // MARK: Private properties
 
     private let books: [Book]
+    private let delays: [String : Duration]
     private let queries: [String : [String]]
 
     // MARK: - Initialization
 
-    init(books: [Book] = [], queries: [String : [String]] = [:]) {
+    init(books: [Book] = [], queries: [String : [String]] = [:], delays: [String : Duration] = [:]) {
         self.books = books
         self.queries = queries
+        self.delays = delays
     }
 
     // MARK: - Methods
@@ -34,7 +36,10 @@ final class CatalogMockService: CatalogService {
     }
 
     func getBook(by id: String) async -> Book? {
-        books.first { $0.id == id }
+        if let delay = delays[id] {
+            try? await Task.sleep(for: delay)
+        }
+        return books.first { $0.id == id }
     }
 
 }

--- a/WormTests/Mocks/SearchMockModel.swift
+++ b/WormTests/Mocks/SearchMockModel.swift
@@ -19,15 +19,15 @@ actor SearchMockModel: SearchModel {
     // MARK: SearchModel protocol properties
 
     @Published
-    private(set) var books = Set<Book>()
-    var booksPublisher: Published<Set<Book>>.Publisher { $books }
+    private(set) var books = [Book]()
+    var booksPublisher: Published<[Book]>.Publisher { $books }
     @Published
     private(set) var favoriteBookIDs = Set<String>()
     var favoriteBookIDsPublisher: Published<Set<String>>.Publisher { $favoriteBookIDs }
 
     // MARK: - Initialization
 
-    init(books: Set<Book> = [], favoriteBookIDs: Set<String> = []) async {
+    init(books: [Book] = [], favoriteBookIDs: Set<String> = []) async {
         self.books = books
         self.favoriteBookIDs = favoriteBookIDs
     }

--- a/WormTests/Tests/Screens/Recommendations/RecommendationsDefaultViewModelTests.swift
+++ b/WormTests/Tests/Screens/Recommendations/RecommendationsDefaultViewModelTests.swift
@@ -59,7 +59,7 @@ struct RecommendationsDefaultViewModelTests {
     @MainActor
     @Test(.timeLimit(.minutes(1)))
     func recommendations_update() async {
-        let recommendations: Set = [Book(id: "1", authors: [], title: "", description: "Desc")]
+        let recommendations = [Book(id: "1", authors: [], title: "", description: "Desc")]
         let vm: any RecommendationsViewModel = await RecommendationsDefaultViewModel(
             model: RecommendationsMockModel(recommendations: recommendations),
             onboardingService: OnboardingMockService(),
@@ -77,7 +77,7 @@ struct RecommendationsDefaultViewModelTests {
     @Test(.timeLimit(.minutes(1)))
     func recommendations_update_afterTogglingFavorite() async {
         let id = "1"
-        let recommendations: Set = [Book(id: id, authors: [], title: "", description: "Desc")]
+        let recommendations = [Book(id: id, authors: [], title: "", description: "Desc")]
         let vm: any RecommendationsViewModel = await RecommendationsDefaultViewModel(
             model: RecommendationsMockModel(recommendations: recommendations),
             onboardingService: OnboardingMockService(),
@@ -218,7 +218,7 @@ struct RecommendationsDefaultViewModelTests {
     @Test
     func recommendations_update_whenAppliedFilters_change() async {
         let book = Book(id: "1", authors: [], title: "", description: "Desc", rating: 3.0)
-        let recommendations: Set = [book]
+        let recommendations = [book]
 
         let vm: any RecommendationsViewModel = await RecommendationsDefaultViewModel(
             model: RecommendationsMockModel(recommendations: recommendations),
@@ -246,15 +246,15 @@ struct RecommendationsDefaultViewModelTests {
         // MARK: RecommendationsModel protocol properties
 
         var favoriteBookIDsPublisher: Published<Set<String>>.Publisher { $favoriteBookIDs }
-        var recommendationsPublisher: Published<Set<Book>>.Publisher { $recommendations }
+        var recommendationsPublisher: Published<[Book]>.Publisher { $recommendations }
         @Published
         private(set) var favoriteBookIDs: Set<String>
         @Published
-        private(set) var recommendations: Set<Book>
+        private(set) var recommendations: [Book]
 
         // MARK: - Initialization
 
-        init(recommendations: Set<Book> = [], favoriteBookIDs: Set<String> = []) async {
+        init(recommendations: [Book] = [], favoriteBookIDs: Set<String> = []) async {
             self.recommendations = recommendations
             self.favoriteBookIDs = favoriteBookIDs
         }

--- a/WormTests/Tests/Screens/Search/SearchDefaultViewModelTests.swift
+++ b/WormTests/Tests/Screens/Search/SearchDefaultViewModelTests.swift
@@ -108,7 +108,7 @@ struct SearchDefaultViewModelTests {
     @MainActor
     @Test(.timeLimit(.minutes(1)))
     func books_update() async {
-        let books: Set = [Book(id: "1", authors: [], title: "", description: "Desc")]
+        let books = [Book(id: "1", authors: [], title: "", description: "Desc")]
         let vm: any SearchViewModel = await SearchDefaultViewModel(
             model: SearchMockModel(books: books),
             onboardingService: OnboardingMockService(),
@@ -126,7 +126,7 @@ struct SearchDefaultViewModelTests {
     @Test(.timeLimit(.minutes(1)))
     func books_update_withFavorite() async {
         let id = "1"
-        let books: Set = [Book(id: id, authors: [], title: "", description: "Desc")]
+        let books = [Book(id: id, authors: [], title: "", description: "Desc")]
         let vm: any SearchViewModel = await SearchDefaultViewModel(
             model: SearchMockModel(books: books, favoriteBookIDs: [id]),
             onboardingService: OnboardingMockService(),
@@ -144,7 +144,7 @@ struct SearchDefaultViewModelTests {
     @Test(.timeLimit(.minutes(1)))
     func books_update_afterTogglingFavorite() async {
         let id = "1"
-        let books: Set = [Book(id: id, authors: [], title: "", description: "Desc")]
+        let books = [Book(id: id, authors: [], title: "", description: "Desc")]
         let vm: any SearchViewModel = await SearchDefaultViewModel(
             model: SearchMockModel(books: books),
             onboardingService: OnboardingMockService(),

--- a/WormTests/Tests/Screens/Search/SearchServiceBasedModelTests.swift
+++ b/WormTests/Tests/Screens/Search/SearchServiceBasedModelTests.swift
@@ -101,7 +101,37 @@ struct SearchServiceBasedModelTests {
         )
 
         await model.searchBooks(by: query)
-        while await model.books != Set(books) {
+        while await model.books != books {
+            await Task.yield()
+        }
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func books_update_onSearch_preservesRelevanceOrder_regardlessOfFetchCompletionOrder() async {
+        let query = "Query"
+
+        let books = [
+            Book(id: "1", authors: [], title: "First", description: "Desc1"),
+            Book(id: "2", authors: [], title: "Second", description: "Desc2"),
+            Book(id: "3", authors: [], title: "Third", description: "Desc3")
+        ]
+        let result = books.map { $0.id }
+
+        let model: any SearchModel = await SearchServiceBasedModel(
+            catalogService: CatalogMockService(
+                books: books,
+                queries: [query : result],
+                delays: [
+                    "1" : .milliseconds(300),
+                    "2" : .milliseconds(150),
+                    "3" : .milliseconds(0)
+                ]
+            ),
+            favoritesService: FavoritesMockService()
+        )
+
+        await model.searchBooks(by: query)
+        while await model.books != books {
             await Task.yield()
         }
     }
@@ -162,7 +192,7 @@ struct SearchServiceBasedModelTests {
         await model.searchBooks(by: query2)
         await model.searchBooks(by: query1)
 
-        while await model.books != Set(books1) {
+        while await model.books != books1 {
             await Task.yield()
         }
     }


### PR DESCRIPTION
## Summary
- `RecommendationsModel.recommendations` and `SearchModel.books` were typed `Set<Book>`, which silently discards insertion order. The relevance sorting computed upstream (recommendation priority, search ranking) never reached the UI, despite the onboarding text promising "Recommendations are shown in the order of their relevance."
- Search results had an additional bug: book fetches for a query run concurrently, so even with an ordered collection, results would land in whatever order their network fetch happened to finish in — not the relevance order returned by the search API.

## Fix
- Both properties are now `[Book]`.
- `RecommendationsModel`'s `didSet` no longer wraps its sorted output in `Set(...)`.
- `SearchModel` now writes fetched books into an id-keyed dictionary and rebuilds the `books` array from the original search-result order on every fetch completion, so display order always matches relevance regardless of which fetch finishes first.

## Test plan
- [x] Updated all mocks/tests using `Set<Book>` to `[Book]`.
- [x] Added `books_update_onSearch_preservesRelevanceOrder_regardlessOfFetchCompletionOrder`, which deliberately makes the most relevant result the slowest to fetch and asserts final order still matches relevance.
- [x] Verified that test fails (times out) against a naive completion-order-append implementation, and passes with the fix.
- [x] Full suite: 88/88 passing.