### PR TITLE
Fix search/recommendations onboarding flags being cross-wired

### DIFF
--- a/Worm/Sources/Screens/SearchDefaultViewModel.swift
+++ b/Worm/Sources/Screens/SearchDefaultViewModel.swift
@@ -29,10 +29,12 @@ final class SearchDefaultViewModel: MainScreenViewModel, SearchViewModel {
     private(set) var books = [BookViewModel]()
     @Published
     var recommendationsOnboardingShown: Bool {
-        didSet { onboardingService.searchOnboardingShown = recommendationsOnboardingShown }
+        didSet { onboardingService.recommendationsOnboardingShown = recommendationsOnboardingShown }
     }
     @Published
-    var searchOnboardingShown: Bool
+    var searchOnboardingShown: Bool {
+        didSet { onboardingService.searchOnboardingShown = searchOnboardingShown }
+    }
 
     // MARK: Private methods
 
@@ -54,7 +56,7 @@ final class SearchDefaultViewModel: MainScreenViewModel, SearchViewModel {
         self.imageService = imageService
 
         searchOnboardingShown = onboardingService.searchOnboardingShown
-        recommendationsOnboardingShown = onboardingService.searchOnboardingShown
+        recommendationsOnboardingShown = onboardingService.recommendationsOnboardingShown
 
         Task { [weak self] in
             await self?.bind(model: model)

--- a/WormTests/Tests/Screens/Search/SearchDefaultViewModelTests.swift
+++ b/WormTests/Tests/Screens/Search/SearchDefaultViewModelTests.swift
@@ -28,8 +28,8 @@ struct SearchDefaultViewModelTests {
     }
 
     @MainActor
-    @Test
-    func searchOnboarding_update_doesNotUpdatePersistence() async {
+    @Test(.timeLimit(.minutes(1)))
+    func searchOnboarding_update_updatesPersistence() async {
         let value = true
         let service = OnboardingMockService(onboardingShown: value)
         let vm: any SearchViewModel = await SearchDefaultViewModel(
@@ -39,7 +39,9 @@ struct SearchDefaultViewModelTests {
         let newValue = !value
         vm.searchOnboardingShown = newValue
 
-        #expect(service.searchOnboardingShown == value, "Persistence was unexpectedly updated.")
+        while service.searchOnboardingShown != newValue {
+            await Task.yield()
+        }
     }
 
     @MainActor
@@ -66,7 +68,7 @@ struct SearchDefaultViewModelTests {
         let newValue = !value
         vm.recommendationsOnboardingShown = newValue
 
-        while service.searchOnboardingShown != newValue {
+        while service.recommendationsOnboardingShown != newValue {
             await Task.yield()
         }
     }


### PR DESCRIPTION
## Summary
Three defects in `SearchDefaultViewModel`:
1. `recommendationsOnboardingShown`'s `didSet` wrote to `onboardingService.searchOnboardingShown` (wrong key).
2. `searchOnboardingShown` had no `didSet` at all, so dismissing the search tooltip was never persisted and it reappeared on every launch.
3. `init` seeded `recommendationsOnboardingShown` from `onboardingService.searchOnboardingShown` (wrong source).

The existing tests encoded this as expected behavior — `searchOnboarding_update_doesNotUpdatePersistence` explicitly asserted persistence *didn't* happen, and `recommendationsOnboarding_update_updatesPersistence` was checking the wrong service key.

## Fix
- Each flag now reads and writes its own key.
- `searchOnboardingShown` now persists via `didSet`.

## Test plan
- [x] Renamed `searchOnboarding_update_doesNotUpdatePersistence` → `searchOnboarding_update_updatesPersistence`, now asserts persistence does happen.
- [x] Fixed `recommendationsOnboarding_update_updatesPersistence` to check `recommendationsOnboardingShown` instead of `searchOnboardingShown`.
- [x] Verified both updated tests fail (time out) against the original buggy code and pass with the fix.
- [x] Full suite: 87/87 passing.