### PR TITLE
Revive dead stableSorted tests

### DIFF
--- a/WormTests/Tests/Extensions/SequenceTests.swift
+++ b/WormTests/Tests/Extensions/SequenceTests.swift
@@ -13,6 +13,7 @@ struct SequenceTests {
 
     // MARK: - Methods
 
+    @Test
     func stableSorted_sorts() {
         let items = [
             Item(value: 3),
@@ -31,6 +32,7 @@ struct SequenceTests {
         )
     }
 
+    @Test
     func stableSorted_stable() {
         let item1 = Item(value: 1)
         let item2 = Item(value: 2)


### PR DESCRIPTION
## Summary
`stableSorted_sorts()` and `stableSorted_stable()` in `SequenceTests.swift` were missing the `@Test` attribute, so Swift Testing silently never ran them. The `stableSorted` extension (used for recommendation ranking) was therefore untested — confirmed this was the only test file in the suite with this issue.

## Fix
Added the missing `@Test` attribute to both functions.

## Test plan
- [x] Both tests now execute and pass.
- [x] Full suite: 89/89 passing.