### PR TITLE
Service-layer consistency fixes

### DIFF
--- a/Worm/Sources/Service/Favorites/FavoritesService.swift
+++ b/Worm/Sources/Service/Favorites/FavoritesService.swift
@@ -117,7 +117,10 @@ actor FavoritesPersistenceService: FavoritesService {
 
     func removeFromFavoriteBook(withID id: String) {
         do {
-            try ModelContext(container).delete(model: FavoriteBook.self, where: #Predicate { $0.id == id })
+            let context = ModelContext(container)
+            try context.delete(model: FavoriteBook.self, where: #Predicate { $0.id == id })
+            try context.save()
+
             updateFavoriteBooks()
         } catch {
             // TODO: Proper error handling.

--- a/Worm/Sources/Service/OnboardingService.swift
+++ b/Worm/Sources/Service/OnboardingService.swift
@@ -30,11 +30,11 @@ final class OnboardingPersistentService: OnboardingService {
 
     var recommendationsOnboardingShown: Bool {
         get { userDefaults.bool(forKey: .recommendationsOnboardingShown) }
-        set { userDefaults.setValue(newValue, forKey: .recommendationsOnboardingShown) }
+        set { userDefaults.set(newValue, forKey: .recommendationsOnboardingShown) }
     }
     var searchOnboardingShown: Bool {
         get { userDefaults.bool(forKey: .searchOnboardingShown) }
-        set { userDefaults.setValue(newValue, forKey: .searchOnboardingShown) }
+        set { userDefaults.set(newValue, forKey: .searchOnboardingShown) }
     }
 
     // MARK: Private properties

--- a/Worm/WormApp.swift
+++ b/Worm/WormApp.swift
@@ -43,30 +43,28 @@ struct WormApp: App {
 
         return CatalogGoodreadsService(goodreadsService: goodreadsService, cacheService: cacheService)
     }()
-    private var favoritesService: FavoritesService {
-        get {
-            let modelContainer: ModelContainer = {
+    private let favoritesService: FavoritesService = {
+        let modelContainer: ModelContainer = {
 #if DEBUG
-                let storedInMemory = ProcessInfo.processInfo.environment["TEST"] != nil
+            let storedInMemory = ProcessInfo.processInfo.environment["TEST"] != nil
 #else
-                let storedInMemory = false
+            let storedInMemory = false
 #endif
-                let schema = Schema(
-                    [BlockedBook.self,
-                     FavoriteBook.self],
-                    version: Schema.Version(1, 0, 0)
-                )
-                let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: storedInMemory)
-                do {
-                    return try ModelContainer(for: schema, configurations: configuration)
-                } catch {
-                    // TODO: Proper error handling.
-                    fatalError("Could not create ModelContainer: \(error)")
-                }
-            }()
-            return FavoritesPersistenceService(modelContainer: modelContainer)
-        }
-    }
+            let schema = Schema(
+                [BlockedBook.self,
+                 FavoriteBook.self],
+                version: Schema.Version(1, 0, 0)
+            )
+            let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: storedInMemory)
+            do {
+                return try ModelContainer(for: schema, configurations: configuration)
+            } catch {
+                // TODO: Proper error handling.
+                fatalError("Could not create ModelContainer: \(error)")
+            }
+        }()
+        return FavoritesPersistenceService(modelContainer: modelContainer)
+    }()
     private let imageService = ImageWebService(webService: URLSession.shared)
     private let onboardingService = OnboardingPersistentService()
 


### PR DESCRIPTION
## Summary
Three small, unrelated fixes to service-layer code that was quietly doing the wrong thing — grouped together since each is a one- or two-line change.

1. **`favoritesService` in `WormApp.swift`** was a computed property that rebuilt a `ModelContainer` + `FavoritesPersistenceService` on every access. It's only read once today, but any second access would spin up a second SQLite stack with its own empty `@Published` state. Made it a stored `let`, mirroring the existing `catalogService` pattern.
2. **`OnboardingService.swift`** used `UserDefaults.setValue(forKey:)` (KVC) instead of `set(forKey:)`, the intended API. Behaviorally equivalent for `Bool`, but a correctness-of-intent cleanup.
3. **`FavoritesService.removeFromFavoriteBook`** didn't call `save()` after its batch delete, unlike the add methods. The batch `delete(model:where:)` API commits without an explicit save today, so this is behavior-preserving, but the inconsistency invited confusion — made it uniform.

## Test plan
- [x] Build succeeds after each change.
- [x] Full suite run after each change: 91/91 passing throughout.