### PR TITLE
Recommendations/Details view-layer fixes

### DIFF
--- a/Worm/Sources/Screens/Details/BookDetailsView.swift
+++ b/Worm/Sources/Screens/Details/BookDetailsView.swift
@@ -15,37 +15,41 @@ struct BookDetailsView<ViewModel: BookDetailsViewModel>: View {
     // MARK: View protocol properties
 
     var body: some View {
-        HStack {
-            Spacer()
-            Button("Close") { dismiss() }
-                .padding()
+        VStack {
+            HStack {
+                Spacer()
+                Button("Close") { dismiss() }
+                    .padding()
+            }
+            ScrollView {
+                if let image = viewModel.image { // TODO: Update if downloaded later.
+                    Image(decorative: image, scale: 1.0)
+                        .padding(.bottom)
+                }
+                Text(viewModel.title)
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+                Text(viewModel.authors)
+                    .font(.subheadline)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+                if let ratingViewModel = viewModel.ratingViewModel {
+                    RatingView(viewModel: ratingViewModel)
+                        .padding(.top, 2.0)
+                        .padding(.horizontal)
+                }
+                Text(viewModel.description)
+                    .font(.caption)
+                    .multilineTextAlignment(.center)
+                    .padding(
+                        [
+                            .top,
+                            .horizontal
+                        ]
+                    )
+            }
         }
-        Spacer()
-        if let image = viewModel.image { // TODO: Update if downloaded later.
-            Image(decorative: image, scale: 1.0)
-                .padding(.bottom)
-        }
-        Text(viewModel.title)
-            .font(.headline)
-            .multilineTextAlignment(.center)
-            .padding(.horizontal)
-        Text(viewModel.authors)
-            .font(.subheadline)
-            .multilineTextAlignment(.center)
-            .padding(.horizontal)
-        if let ratingViewModel = viewModel.ratingViewModel {
-            RatingView(viewModel: ratingViewModel)
-                .padding(.top, 2.0)
-                .padding(.horizontal)
-        }
-        Text(viewModel.description)
-            .font(.caption)
-            .multilineTextAlignment(.center)
-            .padding(
-                [.top,
-                 .horizontal]
-            )
-        Spacer()
     }
 
     // MARK: Private properties

--- a/Worm/Sources/Screens/Details/Rating/RatingView.swift
+++ b/Worm/Sources/Screens/Details/Rating/RatingView.swift
@@ -16,8 +16,8 @@ struct RatingView: View {
 
     var body: some View {
         HStack(spacing: 4.0) {
-            ForEach(viewModel.units, id: \.self) {
-                Image(systemName: imageName(for: $0))
+            ForEach(Array(viewModel.units.enumerated()), id: \.offset) {
+                Image(systemName: imageName(for: $1))
                     .accessibilityHidden(true)
             }
         }

--- a/Worm/Sources/Screens/Recommendations/RecommendationsView.swift
+++ b/Worm/Sources/Screens/Recommendations/RecommendationsView.swift
@@ -28,12 +28,7 @@ struct RecommendationsView<ViewModel: RecommendationsViewModel>: View {
                             }
                                 .buttonStyle(.plain)
                                 .contextMenu {
-                                    Button("Delete") {
-                                        viewModel
-                                            .recommendations
-                                            .filter { $0.id == book.id }
-                                            .forEach { viewModel.blockRecommendation($0) }
-                                    }
+                                    Button("Delete") { viewModel.blockRecommendation(book) }
                                 }
                         }
                             .onDelete { indexSet in


### PR DESCRIPTION
## Summary
Three small SwiftUI correctness/cleanliness fixes in the Recommendations and Details screens, grouped together.

1. **`BookDetailsView.body`** returned a bare `TupleView` of top-level siblings with no `VStack`/`ScrollView` – `Spacer()` between top-level views has no defined axis to expand along, and long descriptions couldn't scroll. The close button now stays fixed at the top in an outer `VStack`, while the book info scrolls in a `ScrollView`.
2. **`RatingView`**'s `ForEach(viewModel.units, id: \.self)` produced duplicate IDs since `RatingUnit` values repeat (e.g. multiple `.empty` entries) – a known source of SwiftUI diffing glitches. Now identifies by array offset instead.
3. **`RecommendationsView`**'s delete context menu did `viewModel.recommendations.filter { $0.id == book.id }.forEach { viewModel.blockRecommendation($0) }` instead of just `blockRecommendation(book)` – `book` is already in scope from the enclosing `ForEach`.

## Test plan
- [x] Build succeeds after each change.
- [x] Full suite run after each change: 91/91 passing throughout.
- [x] `BookDetailsViewUITests` (2/2) re-run after the `BookDetailsView` and `RatingView` changes — details screen opens correctly and rating visibility/accessibility label behavior is unaffected.