### PR TITLE
Bound concurrent book fetches during search

### DIFF
--- a/Worm/Sources/Screens/Search/SearchModel.swift
+++ b/Worm/Sources/Screens/Search/SearchModel.swift
@@ -52,15 +52,16 @@ actor SearchServiceBasedModel: SearchModel {
 
     // MARK: Private properties
 
+    private static let maxConcurrentFetches = 5
     private let catalogService: CatalogService
     private let favoritesService: FavoritesService
     private let queryDelay: Duration?
     private lazy var cancellables = Set<AnyCancellable>()
+    private var currentFetchTask: Task<(), Never>?
     private var currentSearchResult = [String]() {
         didSet {
-            currentSearchResult.forEach { result in
-                Task { await handleSearchResult(result) }
-            }
+            currentFetchTask?.cancel()
+            currentFetchTask = Task { await fetchBooks(for: currentSearchResult) }
         }
     }
     private var currentSearchTask: Task<(), Error>?
@@ -133,6 +134,26 @@ actor SearchServiceBasedModel: SearchModel {
 
     private func updateFavoriteBookIDs(_ favoriteBookIDs: Set<String>) {
         self.favoriteBookIDs = favoriteBookIDs
+    }
+
+    private func fetchBooks(for results: [String]) async {
+        await withTaskGroup(of: Void.self) {
+            var pendingResults = results.makeIterator()
+
+            for _ in 0..<min(Self.maxConcurrentFetches, results.count) {
+                guard let result = pendingResults.next() else {
+                    break
+                }
+                $0.addTask { await self.handleSearchResult(result) }
+            }
+            while await $0.next() != nil {
+                guard !Task.isCancelled,
+                      let result = pendingResults.next() else {
+                    continue
+                }
+                $0.addTask { await self.handleSearchResult(result) }
+            }
+        }
     }
 
     private func handleSearchResult(_ result: String) async {

--- a/WormTests/Tests/Screens/Search/SearchServiceBasedModelTests.swift
+++ b/WormTests/Tests/Screens/Search/SearchServiceBasedModelTests.swift
@@ -197,4 +197,85 @@ struct SearchServiceBasedModelTests {
         }
     }
 
+    @Test(.timeLimit(.minutes(1)))
+    func booksFetch_supportsConcurrency() async {
+        let books = (1...20).map { Book(id: "\($0)", authors: [], title: "Book \($0)", description: "Desc") }
+        let query = "Query"
+        let result = books.map { $0.id }
+        let catalogService = ConcurrencyTrackingCatalogMockService(books: books, queries: [query : result])
+
+        let model: any SearchModel = await SearchServiceBasedModel(
+            catalogService: catalogService, favoritesService: FavoritesMockService()
+        )
+
+        await model.searchBooks(by: query)
+        while await model.books.count != books.count {
+            await Task.yield()
+        }
+
+        let peakConcurrency = await catalogService.peakConcurrency
+        #expect(peakConcurrency > 1, "Fetches should run concurrently.")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func booksFetch_boundsConcurrency() async {
+        let books = (1...20).map { Book(id: "\($0)", authors: [], title: "Book \($0)", description: "Desc") }
+        let query = "Query"
+        let result = books.map { $0.id }
+        let catalogService = ConcurrencyTrackingCatalogMockService(books: books, queries: [query : result])
+
+        let model: any SearchModel = await SearchServiceBasedModel(
+            catalogService: catalogService, favoritesService: FavoritesMockService()
+        )
+
+        await model.searchBooks(by: query)
+        while await model.books.count != books.count {
+            await Task.yield()
+        }
+
+        let peakConcurrency = await catalogService.peakConcurrency
+        #expect(peakConcurrency <= 5, "Concurrent fetches should be bounded.")
+    }
+
+    // MARK: -
+
+    private actor ConcurrencyTrackingCatalogMockService: CatalogService {
+
+        // MARK: - Properties
+
+        private(set) var peakConcurrency = 0
+
+        // MARK: Private properties
+
+        private let books: [Book]
+        private let queries: [String : [String]]
+        private var currentConcurrency = 0
+
+        // MARK: - Initialization
+
+        init(books: [Book], queries: [String : [String]]) {
+            self.books = books
+            self.queries = queries
+        }
+
+        // MARK: - Methods
+
+        // MARK: CatalogService protocol methods
+
+        func searchBooks(_ query: String) async -> [String] {
+            queries[query] ?? []
+        }
+
+        func getBook(by id: String) async -> Book? {
+            currentConcurrency += 1
+            peakConcurrency = max(peakConcurrency, currentConcurrency)
+
+            try? await Task.sleep(for: .milliseconds(50))
+            currentConcurrency -= 1
+
+            return books.first { $0.id == id }
+        }
+
+    }
+
 }


### PR DESCRIPTION
## Summary
`currentSearchResult`'s `didSet` spawned one unstructured `Task` per result ID with no concurrency limit — a large result set fired N simultaneous network calls.

## Fix
Fetches now run through a bounded `TaskGroup` (`fetchBooks(for:)`), capped at `maxConcurrentFetches = 5` concurrent requests. As each fetch completes, the next pending result is scheduled. A newer search cancels the in-flight batch via `currentFetchTask`, same pattern as the existing `currentSearchTask` debounce/cancel logic.

## Test plan
- [x] Added `booksFetch_supportsConcurrency` / `booksFetch_boundsConcurrency` with a `ConcurrencyTrackingCatalogMockService` that tracks peak concurrent `getBook` calls — asserts concurrency is both genuinely parallel (`>1`) and bounded (`<=5`).
- [x] Verified the bounds assertion fails (peak hits 20) against the old unbounded implementation, and passes with the fix.
- [x] Full suite: 93/93 passing. (One pre-existing flaky test, `favoriteBooksIDs_update`, was confirmed to flake identically on unmodified `master` — unrelated to this change.)