### PR TITLE
Add LRU eviction to the in-memory cache

### DIFF
--- a/Worm/Sources/Service/Cache/CacheService.swift
+++ b/Worm/Sources/Service/Cache/CacheService.swift
@@ -16,11 +16,12 @@ protocol CacheService<Key, Entity>: Actor {
 
     // MARK: - Properties
 
-    /// The stored data, in no particular order.
-    var storage: [Key: Entity] { get }
-
     // MARK: - Methods
 
+    /// Returns the stored value for the given key, if present.
+    /// - Parameter key: The key, associated with the object.
+    /// - Returns: The stored object, or `nil` if there's none stored for the given key.
+    func value(for key: Key) -> Entity?
     /// Inserts a new object to the storage.
     /// - Parameters:
     ///   - entity: The new object to store.
@@ -31,23 +32,59 @@ protocol CacheService<Key, Entity>: Actor {
 
 // MARK: -
 
-/// Stores results of computations or distributed calls to provide them in a more efficient manner than repeating the initial call again.
+/// Stores results of computations or distributed calls to provide them in a more efficient manner than repeating the
+///   initial call again.
 ///
-/// Uses the in-memory kind of storage, which is nor persisted across the app launches.
+/// Uses the in-memory kind of storage, which is nor persisted across the app launches. Once the number of stored
+///   entities reaches `capacity`, the LRU one is evicted to make room for a new one.
 actor CacheInMemoryService<Key: Hashable, Entity>: CacheService {
 
     // MARK: - Properties
 
-    // MARK: CacheService protocol properties
+    // MARK: Private properties
 
-    private(set) var storage = [Key : Entity]()
+    private let capacity: Int
+    private var recencyOrder = [Key]()
+    private var storage = [Key: Entity]()
+
+    // MARK: - Initialization
+
+    /// Creates a cache service, backed by an in-memory storage.
+    /// - Parameter capacity: The maximum number of entities to store at once, before the least recently used one gets
+    ///   evicted.
+    init(capacity: Int = 200) {
+        self.capacity = capacity
+    }
 
     // MARK: - Methods
 
     // MARK: CacheService protocol methods
 
+    func value(for key: Key) -> Entity? {
+        guard let entity = storage[key] else {
+            return nil
+        }
+        markUsed(key)
+
+        return entity
+    }
+
     func insert(_ entity: Entity, for key: Key) {
         storage[key] = entity
+        markUsed(key)
+
+        if storage.count > capacity,
+        let leastRecentlyUsed = recencyOrder.first {
+            storage.removeValue(forKey: leastRecentlyUsed)
+            recencyOrder.removeFirst()
+        }
+    }
+
+    // MARK: Private methods
+
+    private func markUsed(_ key: Key) {
+        recencyOrder.removeAll { $0 == key }
+        recencyOrder.append(key)
     }
 
 }

--- a/Worm/Sources/Service/CatalogService.swift
+++ b/Worm/Sources/Service/CatalogService.swift
@@ -58,7 +58,7 @@ final class CatalogGoodreadsService: CatalogService {
     }
 
     func getBook(by id: String) async -> Book? {
-        if let book = await cacheService.storage[id] {
+        if let book = await cacheService.value(for: id) {
             return book
         }
 

--- a/WormTests/Tests/Service/CacheInMemoryServiceTests.swift
+++ b/WormTests/Tests/Service/CacheInMemoryServiceTests.swift
@@ -1,0 +1,58 @@
+//
+//  CacheInMemoryServiceTests.swift
+//  WormTests
+//
+//  Created by Lazarev-Zubov, Nikita on 8.7.2026.
+//
+
+import Testing
+@testable
+import Worm
+
+struct CacheInMemoryServiceTests {
+
+    // MARK: - Methods
+
+    @Test
+    func value_nil_whenNotInserted() async {
+        let cache = CacheInMemoryService<String, Int>()
+        await #expect(cache.value(for: "1") == nil)
+    }
+
+    @Test
+    func value_returnsInsertedEntity() async {
+        let cache = CacheInMemoryService<String, Int>()
+        await cache.insert(1, for: "1")
+
+        await #expect(cache.value(for: "1") == 1)
+    }
+
+    @Test
+    func insert_evictsLeastRecentlyUsed_whenOverCapacity() async {
+        let cache = CacheInMemoryService<String, Int>(capacity: 2)
+
+        await cache.insert(1, for: "1")
+        await cache.insert(2, for: "2")
+        await cache.insert(3, for: "3")
+
+        await #expect(cache.value(for: "1") == nil, "The least recently used entity should've been evicted.")
+        await #expect(cache.value(for: "2") == 2)
+        await #expect(cache.value(for: "3") == 3)
+    }
+
+    @Test
+    func value_refreshesRecency_protectingFromEviction() async {
+        let cache = CacheInMemoryService<String, Int>(capacity: 2)
+
+        await cache.insert(1, for: "1")
+        await cache.insert(2, for: "2")
+
+        _ = await cache.value(for: "1") // Marks "1" as more recently used than "2".
+        await cache.insert(3, for: "3")
+
+        await #expect(cache.value(for: "2") == nil, "\"2\" was the least recently used and should've been evicted.")
+        await #expect(cache.value(for: "1") == 1, "\"1\" was accessed after \"2\" and should've been kept.")
+        await #expect(cache.value(for: "3") == 3)
+    }
+
+}


### PR DESCRIPTION
## Summary
`CacheInMemoryService` never evicted, growing unbounded for the life of the session. It also exposed its raw storage dict via a `storage` property that callers read directly, bypassing any hook the actor could use to track access.

## Fix
- Replaced direct `storage` access with a `value(for:)` accessor.
- Added capacity-bounded LRU eviction (default 200 entries). Both reads (`value(for:)`) and writes (`insert`) refresh an entry's recency; inserting past capacity evicts the least recently used entry.
- `CatalogGoodreadsService.getBook` updated to use `cacheService.value(for:)` instead of `cacheService.storage[id]`.

## Test plan
- [x] Added `CacheInMemoryServiceTests.swift` – no test coverage existed for this file before. Covers basic get/insert, eviction of the least-recently-used entry at capacity, and that accessing an entry protects it from eviction — verified purely through the public API (no test-only properties added to the cache).
- [x] Full suite: 95/95 passing. (One pre-existing flaky test in `SearchServiceBasedModelTests`, unrelated to this change, was confirmed to flake identically on unmodified `master` earlier in this review.)