### PR TITLE
Extract shared preview/debug book fixture

### DIFF
--- a/Worm/Sources/Extensions/Book+PreviewFixtures.swift
+++ b/Worm/Sources/Extensions/Book+PreviewFixtures.swift
@@ -1,0 +1,139 @@
+//
+//  Book+PreviewFixtures.swift
+//  Worm
+//
+//  Created by Lazarev-Zubov, Nikita on 9.7.2026.
+//
+
+#if DEBUG
+import GoodreadsService
+
+extension Book {
+
+    // MARK: - Properties
+
+    static let previewFixtures: [Book] = [
+        Book(
+            id: "1",
+            authors: ["J.R.R. Tolkien"],
+            title: "The Lord of the Rings",
+            description: "A sensitive hobbit unexpectedly saves the situation.",
+            rating: nil,
+            similarBookIDs: ["15"]
+        ),
+        Book(
+            id: "2",
+            authors: ["Michael Bond"],
+            title: "Paddington Pop-Up London",
+            description: "A cute pop-up book about London, the capital of The United Kingdom.",
+            rating: 0.12,
+            similarBookIDs: ["14"]
+        ),
+        Book(
+            id: "3",
+            authors: ["J.K. Rowling"],
+            title: "Harry Potter and the Sorcerer's Stone",
+            description: "Another sensitive teenager saves the day thank to his friends.",
+            rating: 1.23,
+            similarBookIDs: ["13"]
+        ),
+        Book(
+            id: "4",
+            authors: ["George R.R. Martin"],
+            title: "A Game of Thrones",
+            description: "Caligula with magic and dragons.",
+            rating: 2.34,
+            similarBookIDs: ["12"]
+        ),
+        Book(
+            id: "5",
+            authors: ["Frank Herbert"],
+            title: "Dune I",
+            description: "A good example of why immigrants can be useful to a country (or a planet).",
+            rating: 3.45,
+            similarBookIDs: ["11"]
+        ),
+        Book(
+            id: "6",
+            authors: ["Mikhail Bulgakov"],
+            title: "The Master and Margarita",
+            description: "An exception that proves that some books from the public school program are actually good.",
+            rating: 4.56,
+            similarBookIDs: ["10"]
+        ),
+        Book(
+            id: "7",
+            authors: ["Alan Moore"],
+            title: "Watchmen",
+            description: "Aging superheroes with psychological issues face the demons of their past.",
+            rating: nil,
+            similarBookIDs: ["9"]
+        ),
+        Book(
+            id: "8",
+            authors: ["Steve McConnell"],
+            title: "Code Complete",
+            description: "How to make your code a bit less shitty.",
+            rating: 0.12,
+            similarBookIDs: ["8"]
+        ),
+        Book(
+            id: "9",
+            authors: ["Jane Austen"],
+            title: "Pride and Prejudice",
+            description: "More than just a love story.",
+            rating: 1.23,
+            similarBookIDs: ["7"]
+        ),
+        Book(
+            id: "10",
+            authors: ["Martin Fowler"],
+            title: "Refactoring: Improving the Design of Existing Code",
+            description: "A step-by-step guide how to make your code bearable to work with.",
+            rating: 2.34,
+            similarBookIDs: ["6"]
+        ),
+        Book(
+            id: "11",
+            authors: ["Stephen King"],
+            title: "The Shining",
+            description: "How the family can drive a person crazy, when they are locked up together.",
+            rating: 3.45,
+            similarBookIDs: ["5"]
+        ),
+        Book(
+            id: "12",
+            authors: ["Hannah Arendt"],
+            title: "Eichmann in Jerusalem: A Report on the Banality of Evil",
+            description: "How the Jew made their situation even worse during WWII.",
+            rating: 4.56,
+            similarBookIDs: ["4"]
+        ),
+        Book(
+            id: "13",
+            authors: ["Fyodor Dostoyevsky"],
+            title: "The Idiot",
+            description: "A book about a nice person in the world of idiots (i.e., the real world).",
+            rating: nil,
+            similarBookIDs: ["3"]
+        ),
+        Book(
+            id: "14",
+            authors: ["Ken Kesey"],
+            title: "Sometimes a Great Notion",
+            description: "A story that proves you must stay away of your family after you grow up.",
+            rating: 1.23,
+            similarBookIDs: ["2"]
+        ),
+        Book(
+            id: "15",
+            authors: ["Haruki Murakami"],
+            title: "The Wind-Up Bird Chronicle",
+            description: "A half anime-pervert, half meditating phantasy.",
+            rating: 2.34,
+            similarBookIDs: ["1"]
+        )
+    ]
+
+}
+#endif

--- a/Worm/Sources/Screens/Favorites/FavoritesViewModel.swift
+++ b/Worm/Sources/Screens/Favorites/FavoritesViewModel.swift
@@ -86,9 +86,8 @@ final class FavoritesDefaultViewModel: FavoritesViewModel {
 
 }
 
-// MARK: -
-
 #if DEBUG
+import GoodreadsService
 
 final class FavoritesPreviewsViewModel: FavoritesViewModel {
 
@@ -96,143 +95,7 @@ final class FavoritesPreviewsViewModel: FavoritesViewModel {
 
     // MARK: FavoritesViewModel protocol properties
 
-    private(set) var favorites = [
-        BookViewModel(
-            id: "1",
-            authors: "J.R.R. Tolkien",
-            title: "The Lord of the Rings",
-            description: "A sensitive hobbit unexpectedly saves the situation.",
-            imageURL: nil,
-            rating: nil,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "2",
-            authors: "Michael Bond",
-            title: "Paddington Pop-Up London",
-            description: "A cute pop-up book about London, the capital of The United Kingdom.",
-            imageURL: nil,
-            rating: 1.23,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "3",
-            authors: "J.K. Rowling",
-            title: "Harry Potter and the Sorcecer's Stone",
-            description: "Another sensitive teenager saves the day thank to his friends.",
-            imageURL: nil,
-            rating: 2.34,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "4",
-            authors: "George R.R. Martin",
-            title: "A Game of Thrones",
-            description: "Caligula with magic and dragons.",
-            imageURL: nil,
-            rating: 3.45,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "5",
-            authors: "Frank Herbert",
-            title: "Dune I",
-            description: "A good example of why immigrants can be useful to a country (or a planet).",
-            imageURL: nil,
-            rating: 4.56,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "6",
-            authors: "Mikhail Bulgakov",
-            title: "The Master and Margarita",
-            description: "An exception that proves that some books from the public school program are actually good.",
-            imageURL: nil,
-            rating: nil,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "7",
-            authors: "Alan Moore",
-            title: "Watchmen",
-            description: "Aging superheroes with psychological issues face the demons of their past.",
-            imageURL: nil,
-            rating: 0.12,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "8",
-            authors: "Steve McConnell",
-            title: "Code Complete",
-            description: "How to make your code a bit less shitty.",
-            imageURL: nil,
-            rating: 1.23,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "9",
-            authors: "Jane Austen",
-            title: "Pride and Prejudice",
-            description: "More than just a love story.",
-            imageURL: nil,
-            rating: 2.34,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "10",
-            authors: "Martin Fowler",
-            title: "Refactoring: Improving the Design of Existing Code",
-            description: "A step-by-step guide how to make your code bearable to work with.",
-            imageURL: nil,
-            rating: 3.45,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "11",
-            authors: "Stephen King",
-            title: "The Shining",
-            description: "How the family can drive a person crazy, when they are locked up together.",
-            imageURL: nil,
-            rating: 4.56,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "12",
-            authors: "Hannah Arendt",
-            title: "Eichmann in Jerusalem: A Report on the Banality of Evil",
-            description: "How the Jew made their situation even worse during WWII.",
-            imageURL: nil,
-            rating: nil,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "13",
-            authors: "Fyodor Dostoyevsky",
-            title: "The Idiot",
-            description: "A book about a nice person in the world of idiots (i.e., the real world).",
-            imageURL: nil,
-            rating: 2.34,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "14",
-            authors: "Ken Kesey",
-            title: "Sometimes a Great Notion",
-            description: "A story that proves you must stay away of your family after you grow up.",
-            imageURL: nil,
-            rating: 3.45,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "15",
-            authors: "Haruki Murakami",
-            title: "The Wind-Up Bird Chronicle",
-            description: "A half anime-pervert, half meditating phantasy.",
-            imageURL: nil,
-            rating: 4.56,
-            favorite: false
-        )
-    ]
+    private(set) var favorites = Book.previewFixtures.map { BookViewModel(book: $0, favorite: false) }
 
     // MARK: - Methods
 
@@ -247,5 +110,4 @@ final class FavoritesPreviewsViewModel: FavoritesViewModel {
     }
 
 }
-
 #endif

--- a/Worm/Sources/Screens/Recommendations/RecommendationsViewModel.swift
+++ b/Worm/Sources/Screens/Recommendations/RecommendationsViewModel.swift
@@ -140,8 +140,7 @@ final class RecommendationsDefaultViewModel: RecommendationsViewModel {
 }
 
 #if DEBUG
-
-// MARK: -
+import GoodreadsService
 
 final class RecommendationsPreviewViewModel: RecommendationsViewModel, ObservableObject {
 
@@ -152,143 +151,7 @@ final class RecommendationsPreviewViewModel: RecommendationsViewModel, Observabl
     @Published
     var appliedFilters = [RecommendationsFilter]()
     var onboardingShown = true
-    let recommendations = [
-        BookViewModel(
-            id: "1",
-            authors: "J.R.R. Tolkien",
-            title: "The Lord of the Rings",
-            description: "A sensitive hobbit unexpectedly saves the situation.",
-            imageURL: nil,
-            rating: nil,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "2",
-            authors: "Michael Bond",
-            title: "Paddington Pop-Up London",
-            description: "A cute pop-up book about London, the capital of The United Kingdom.",
-            imageURL: nil,
-            rating: 0.12,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "3",
-            authors: "J.K. Rowling",
-            title: "Harry Potter and the Sorcecer's Stone",
-            description: "Another sensitive teenager saves the day thank to his friends.",
-            imageURL: nil,
-            rating: 1.23,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "4",
-            authors: "George R.R. Martin",
-            title: "A Game of Thrones",
-            description: "Caligula with magic and dragons.",
-            imageURL: nil,
-            rating: 2.34,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "5",
-            authors: "Frank Herbert",
-            title: "Dune I",
-            description: "A good example of why immigrants can be useful to a country (or a planet).",
-            imageURL: nil,
-            rating: 3.45,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "6",
-            authors: "Mikhail Bulgakov",
-            title: "The Master and Margarita",
-            description: "An exception that proves that some books from the public school program are actually good.",
-            imageURL: nil,
-            rating: 4.56,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "7",
-            authors: "Alan Moore",
-            title: "Watchmen",
-            description: "Aging superheroes with psychological issues face the demons of their past.",
-            imageURL: nil,
-            rating: nil,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "8",
-            authors: "Steve McConnell",
-            title: "Code Complete",
-            description: "How to make your code a bit less shitty.",
-            imageURL: nil,
-            rating: 1.23,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "9",
-            authors: "Jane Austen",
-            title: "Pride and Prejudice",
-            description: "More than just a love story.",
-            imageURL: nil,
-            rating: 2.34,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "10",
-            authors: "Martin Fowler",
-            title: "Refactoring: Improving the Design of Existing Code",
-            description: "A step-by-step guide how to make your code bearable to work with.",
-            imageURL: nil,
-            rating: 3.45,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "11",
-            authors: "Stephen King",
-            title: "The Shining",
-            description: "How the family can drive a person crazy, when they are locked up together.",
-            imageURL: nil,
-            rating: 4.56,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "12",
-            authors: "Hannah Arendt",
-            title: "Eichmann in Jerusalem: A Report on the Banality of Evil",
-            description: "How the Jew made their situation even worse during WWII.",
-            imageURL: nil,
-            rating: nil,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "13",
-            authors: "Fyodor Dostoyevsky",
-            title: "The Idiot",
-            description: "A book about a nice person in the world of idiots (i.e., the real world).",
-            imageURL: nil,
-            rating: 2.34,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "14",
-            authors: "Ken Kesey",
-            title: "Sometimes a Great Notion",
-            description: "A story that proves you must stay away of your family after you grow up.",
-            imageURL: nil,
-            rating: 3.45,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "15",
-            authors: "Haruki Murakami",
-            title: "The Wind-Up Bird Chronicle",
-            description: "A half anime-pervert, half meditating phantasy.",
-            imageURL: nil,
-            rating: 4.56,
-            favorite: false
-        )
-    ]
+    let recommendations = Book.previewFixtures.map { BookViewModel(book: $0, favorite: false) }
 
     // MARK: - Methods
 
@@ -307,5 +170,4 @@ final class RecommendationsPreviewViewModel: RecommendationsViewModel, Observabl
     }
 
 }
-
 #endif

--- a/Worm/Sources/Screens/Search/SearchViewModel.swift
+++ b/Worm/Sources/Screens/Search/SearchViewModel.swift
@@ -22,8 +22,7 @@ protocol SearchViewModel: BookListCellViewModel, BookDetailsPresentable, Observa
 }
 
 #if DEBUG
-
-// MARK: -
+import GoodreadsService
 
 final class SearchPreviewViewModel: SearchViewModel, BookListCellViewModel {
 
@@ -34,143 +33,7 @@ final class SearchPreviewViewModel: SearchViewModel, BookListCellViewModel {
     var query = ""
     var recommendationsOnboardingShown = true
     var searchOnboardingShown = true
-    private(set) var books = [
-        BookViewModel(
-            id: "1",
-            authors: "J.R.R. Tolkien",
-            title: "The Lord of the Rings",
-            description: "A sensitive hobbit unexpectedly saves the situation.",
-            imageURL: nil,
-            rating: nil,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "2",
-            authors: "Michael Bond",
-            title: "Paddington Pop-Up London",
-            description: "A cute pop-up book about London, the capital of The United Kingdom.",
-            imageURL: nil,
-            rating: 0.12,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "3",
-            authors: "J.K. Rowling",
-            title: "Harry Potter and the Sorcecer's Stone",
-            description: "Another sensitive teenager saves the day thank to his friends.",
-            imageURL: nil,
-            rating: 1.23,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "4",
-            authors: "George R.R. Martin",
-            title: "A Game of Thrones",
-            description: "Caligula with magic and dragons.",
-            imageURL: nil,
-            rating: 2.34,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "5",
-            authors: "Frank Herbert",
-            title: "Dune I",
-            description: "A good example of why immigrants can be useful to a country (or a planet).",
-            imageURL: nil,
-            rating: 3.45,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "6",
-            authors: "Mikhail Bulgakov",
-            title: "The Master and Margarita",
-            description: "An exception that proves that some books from the public school program are actually good.",
-            imageURL: nil,
-            rating: 4.56,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "7",
-            authors: "Alan Moore",
-            title: "Watchmen",
-            description: "Aging superheroes with psychological issues face the demons of their past.",
-            imageURL: nil,
-            rating: nil,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "8",
-            authors: "Steve McConnell",
-            title: "Code Complete",
-            description: "How to make your code a bit less shitty.",
-            imageURL: nil,
-            rating: 1.23,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "9",
-            authors: "Jane Austen",
-            title: "Pride and Prejudice",
-            description: "More than just a love story.",
-            imageURL: nil,
-            rating: 2.34,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "10",
-            authors: "Martin Fowler",
-            title: "Refactoring: Improving the Design of Existing Code",
-            description: "A step-by-step guide how to make your code bearable to work with.",
-            imageURL: nil,
-            rating: 3.45,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "11",
-            authors: "Stephen King",
-            title: "The Shining",
-            description: "How the family can drive a person crazy, when they are locked up together.",
-            imageURL: nil,
-            rating: 4.56,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "12",
-            authors: "Hannah Arendt",
-            title: "Eichmann in Jerusalem: A Report on the Banality of Evil",
-            description: "How the Jew made their situation even worse during WWII.",
-            imageURL: nil,
-            rating: nil,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "13",
-            authors: "Fyodor Dostoyevsky",
-            title: "The Idiot",
-            description: "A book about a nice person in the world of idiots (i.e., the real world).",
-            imageURL: nil,
-            rating: 2.34,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "14",
-            authors: "Ken Kesey",
-            title: "Sometimes a Great Notion",
-            description: "A story that proves you must stay away of your family after you grow up.",
-            imageURL: nil,
-            rating: 3.45,
-            favorite: false
-        ),
-        BookViewModel(
-            id: "15",
-            authors: "Haruki Murakami",
-            title: "The Wind-Up Bird Chronicle",
-            description: "A half anime-pervert, half meditating phantasy.",
-            imageURL: nil,
-            rating: 4.56,
-            favorite: false
-        )
-    ]
+    private(set) var books = Book.previewFixtures.map { BookViewModel(book: $0, favorite: false) }
 
     // MARK: - Methods
 
@@ -197,5 +60,4 @@ final class SearchPreviewViewModel: SearchViewModel, BookListCellViewModel {
     }
 
 }
-
 #endif

--- a/Worm/Sources/Service/CatalogService.swift
+++ b/Worm/Sources/Service/CatalogService.swift
@@ -79,143 +79,16 @@ final class CatalogGoodreadsService: CatalogService {
 
 final class CatalogPreviewsService: CatalogService {
 
-    // MARK: - Properties
-
-    // MARK: Private properties
-
-    private static let books = [
-        Book(
-            id: "1",
-            authors: ["J.R.R. Tolkien"],
-            title: "The Lord of the Rings",
-            description: "A sensitive hobbit unexpectedly saves the situation.",
-            rating: nil,
-            similarBookIDs: ["15"]
-        ),
-        Book(
-            id: "2",
-            authors: ["Michael Bond"],
-            title: "Paddington Pop-Up London",
-            description: "A cute pop-up book about London, the capital of The United Kingdom.",
-            rating: 0.12,
-            similarBookIDs: ["14"]
-        ),
-        Book(
-            id: "3",
-            authors: ["J.K. Rowling"],
-            title: "Harry Potter and the Sorcerer's Stone",
-            description: "Another sensitive teenager saves the day thank to his friends.",
-            rating: 1.23,
-            similarBookIDs: ["13"]
-        ),
-        Book(
-            id: "4",
-            authors: ["George R.R. Martin"],
-            title: "A Game of Thrones",
-            description: "Caligula with magic and dragons.",
-            rating: 2.34,
-            similarBookIDs: ["12"]
-        ),
-        Book(
-            id: "5",
-            authors: ["Frank Herbert"],
-            title: "Dune I",
-            description: "A good example of why immigrants can be useful to a country (or a planet).",
-            rating: 3.45,
-            similarBookIDs: ["11"]
-        ),
-        Book(
-            id: "6",
-            authors: ["Mikhail Bulgakov"],
-            title: "The Master and Margarita",
-            description: "An exception that proves that some books from the public school program are actually good.",
-            rating: 4.56,
-            similarBookIDs: ["10"]
-        ),
-        Book(
-            id: "7",
-            authors: ["Alan Moore"],
-            title: "Watchmen",
-            description: "Aging superheroes with psychological issues face the demons of their past.",
-            rating: nil,
-            similarBookIDs: ["9"]
-        ),
-        Book(
-            id: "8",
-            authors: ["Steve McConnell"],
-            title: "Code Complete",
-            description: "How to make your code a bit less shitty.",
-            rating: 0.12,
-            similarBookIDs: ["8"]
-        ),
-        Book(
-            id: "9",
-            authors: ["Jane Austen"],
-            title: "Pride and Prejudice",
-            description: "More than just a love story.",
-            rating: 1.23,
-            similarBookIDs: ["7"]
-        ),
-        Book(
-            id: "10",
-            authors: ["Martin Fowler"],
-            title: "Refactoring: Improving the Design of Existing Code",
-            description: "A step-by-step guide how to make your code bearable to work with.",
-            rating: 2.34,
-            similarBookIDs: ["6"]
-        ),
-        Book(
-            id: "11",
-            authors: ["Stephen King"],
-            title: "The Shining",
-            description: "How the family can drive a person crazy, when they are locked up together.",
-            rating: 3.45,
-            similarBookIDs: ["5"]
-        ),
-        Book(
-            id: "12",
-            authors: ["Hannah Arendt"],
-            title: "Eichmann in Jerusalem: A Report on the Banality of Evil",
-            description: "How the Jew made their situation even worse during WWII.",
-            rating: 4.56,
-            similarBookIDs: ["4"]
-        ),
-        Book(
-            id: "13",
-            authors: ["Fyodor Dostoyevsky"],
-            title: "The Idiot",
-            description: "A book about a nice person in the world of idiots (i.e., the real world).",
-            rating: nil,
-            similarBookIDs: ["3"]
-        ),
-        Book(
-            id: "14",
-            authors: ["Ken Kesey"],
-            title: "Sometimes a Great Notion",
-            description: "A story that proves you must stay away of your family after you grow up.",
-            rating: 1.23,
-            similarBookIDs: ["2"]
-        ),
-        Book(
-            id: "15",
-            authors: ["Haruki Murakami"],
-            title: "The Wind-Up Bird Chronicle",
-            description: "A half anime-pervert, half meditating phantasy.",
-            rating: 2.34,
-            similarBookIDs: ["1"]
-        )
-    ]
-
     // MARK: - Methods
 
     // MARK: Service protocol methods
 
     func searchBooks(_ query: String) async -> [String] {
-        Self.books.map { $0.id }
+        Book.previewFixtures.map { $0.id }
     }
 
     func getBook(by id: String) async -> Book? {
-        Self.books.first { $0.id == id }
+        Book.previewFixtures.first { $0.id == id }
     }
 
 }


### PR DESCRIPTION
## Summary
- `CatalogPreviewsService`, `SearchPreviewViewModel`, `RecommendationsPreviewViewModel`, and `FavoritesPreviewsViewModel` each hardcoded their own copy of the same 15 sample books, and the copies had drifted apart (a "Sorcecer's Stone" typo in 3 of the 4 copies, inconsistent ratings).
- Consolidates them into a single `Book.previewFixtures` source of truth in `Book+PreviewFixtures.swift`, derived from `CatalogService.swift`'s version since it's the one actually exercised in DEBUG/TEST builds (not just Xcode canvas previews).
- Net: -402 lines.

## Test plan
- [x] `xcodebuild build` succeeds
- [x] Full `WormTests` suite passes (93/93)