### PR TITLE
Misc small hygiene fixes

### DIFF
--- a/Worm/Resources/Localizable.xcstrings
+++ b/Worm/Resources/Localizable.xcstrings
@@ -46,8 +46,8 @@
         }
       }
     },
-    "%@ favourite checked" : {
-      "comment" : "Accessibility label for a book and its favourite status",
+    "%@ favorite checked" : {
+      "comment" : "Accessibility label for a book and its favorite status",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -63,8 +63,8 @@
         }
       }
     },
-    "%@ favourite unchecked" : {
-      "comment" : "Accessibility label for a book and its favourite status",
+    "%@ favorite unchecked" : {
+      "comment" : "Accessibility label for a book and its favorite status",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -112,7 +112,7 @@
         }
       }
     },
-    "Favourites" : {
+    "Favorites" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -160,7 +160,7 @@
         }
       }
     },
-    "Recommendations are shown in the order of their relevance and update as you turn some of them down or mark more books as favourites." : {
+    "Recommendations are shown in the order of their relevance and update as you turn some of them down or mark more books as favorites." : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -208,7 +208,7 @@
         }
       }
     },
-    "Start by searching your favourite books and marking them as favourites." : {
+    "Start by searching your favorite books and marking them as favorites." : {
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/Worm/Sources/Extensions/Color.swift
+++ b/Worm/Sources/Extensions/Color.swift
@@ -11,7 +11,7 @@ extension Color {
 
     // MARK: - Properties
 
-    /// The color associated with the "Favourites" screen.
+    /// The color associated with the "Favorites" screen.
     static let favorites = Color(red: (249.0 / 255.0), green: (231.0 / 255.0), blue: (132.0 / 255.0))
     /// The color associated with the "Recommendations" screen.
     static let recommendations = Color(red: (190.0 / 255.0), green: (142.0 / 255.0), blue: (155.0 / 255.0))

--- a/Worm/Sources/Screens/Cell/BookListCell.swift
+++ b/Worm/Sources/Screens/Cell/BookListCell.swift
@@ -71,10 +71,10 @@ struct BookListCell: View {
     private func makeFavoriteButtonAccessibilityLabel(for book: BookViewModel) -> Text {
         book.favorite
             ? Text(
-                "\(book.title) favourite checked", comment: "Accessibility label for a book and its favourite status"
+                "\(book.title) favorite checked", comment: "Accessibility label for a book and its favorite status"
             )
             : Text(
-                "\(book.title) favourite unchecked", comment: "Accessibility label for a book and its favourite status"
+                "\(book.title) favorite unchecked", comment: "Accessibility label for a book and its favorite status"
             )
     }
 

--- a/Worm/Sources/Screens/Main/MainScreen.swift
+++ b/Worm/Sources/Screens/Main/MainScreen.swift
@@ -43,10 +43,10 @@ struct MainScreen<
                 }
             NavigationStack {
                 favoritesView
-                    .navigationTitle("Favourites")
+                    .navigationTitle("Favorites")
             }
                 .tabItem {
-                    Label("Favourites", systemImage: "heart")
+                    Label("Favorites", systemImage: "heart")
                 }
         }
     }

--- a/Worm/Sources/Screens/Main/MainScreen.swift
+++ b/Worm/Sources/Screens/Main/MainScreen.swift
@@ -58,8 +58,6 @@ struct MainScreen<
     private let searchView: SearchView
     @ObservedObject
     private var viewModel: ViewModel
-    @State
-    private var searchQuery = ""
 
     // MARK: - Initialization
 

--- a/Worm/Sources/Screens/OnboardingView.swift
+++ b/Worm/Sources/Screens/OnboardingView.swift
@@ -53,7 +53,7 @@ struct OnboardingView: View {
 // MARK: -
 
 #Preview {
-    OnboardingView(text: "Start by searching your favourite books and marking them as favourites.", color: .favorites)
+    OnboardingView(text: "Start by searching your favorite books and marking them as favorites.", color: .favorites)
 }
 
 #endif

--- a/Worm/Sources/Screens/Recommendations/RecommendationsView.swift
+++ b/Worm/Sources/Screens/Recommendations/RecommendationsView.swift
@@ -40,7 +40,7 @@ struct RecommendationsView<ViewModel: RecommendationsViewModel>: View {
                     if !viewModel.onboardingShown {
                         VStack {
                             OnboardingView(
-                                text: "Recommendations are shown in the order of their relevance and update as you turn some of them down or mark more books as favourites.",
+                                text: "Recommendations are shown in the order of their relevance and update as you turn some of them down or mark more books as favorites.",
                                 localizationComment: "A tooltip that appears on the first launch of the app, explaining how recommendations work",
                                 color: .search
                             )

--- a/Worm/Sources/Screens/Search/SearchView.swift
+++ b/Worm/Sources/Screens/Search/SearchView.swift
@@ -29,7 +29,7 @@ struct SearchView<ViewModel: SearchViewModel>: View {
                 if !viewModel.searchOnboardingShown {
                     VStack {
                         OnboardingView(
-                            text: "Start by searching your favourite books and marking them as favourites.",
+                            text: "Start by searching your favorite books and marking them as favorites.",
                             localizationComment: "A tooltip that appears on the first launch of the app, explaining how to use search",
                             color: .favorites
                         )

--- a/WormTests/Tests/Screens/Favorites/FavoritesDefaultViewModelTests.swift
+++ b/WormTests/Tests/Screens/Favorites/FavoritesDefaultViewModelTests.swift
@@ -49,7 +49,7 @@ struct FavoritesDefaultViewModelTests {
 
     @MainActor
     @Test
-    func testDetailsViewModel_title() async {
+    func detailsViewModel_title() async {
         let vm: any FavoritesViewModel = await FavoritesDefaultViewModel(
             model: FavoritesMockModel(), imageService: ImageMockService()
         )


### PR DESCRIPTION
## Summary

- Renamed `testDetailsViewModel_title` → `detailsViewModel_title` to match the `subject_action_expectation` naming convention used by every other test in the file.
- Removed dead `searchQuery` `@State` from `MainScreen` – declared but never read or written; the search field is bound to `$viewModel.query` instead.
- Normalised "favourite/favorite" spelling to American English across code and `Localizable.xcstrings`. Code identifiers (`FavoritesService`, `Color.favorites`, etc.) already used American spelling; a handful of user-facing strings and their matching catalog keys used British spelling. Renamed 5 catalog keys and 6 matching Swift literals/comments – existing `en`/`ru` translations are untouched.

## Test plan

- [x] `xcodebuild build` succeeds
- [x] Full `WormTests` suite passes (97/97)