### PR TITLE
Make UI tests locale-robust by removing Springboard-driven app deletion

### DIFF
--- a/Worm/Sources/Service/OnboardingService.swift
+++ b/Worm/Sources/Service/OnboardingService.swift
@@ -48,6 +48,12 @@ final class OnboardingPersistentService: OnboardingService {
     ///     app.
     init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
+#if DEBUG
+        if ProcessInfo.processInfo.environment["RESET_ONBOARDING"] != nil {
+            userDefaults.removeObject(forKey: .recommendationsOnboardingShown)
+            userDefaults.removeObject(forKey: .searchOnboardingShown)
+        }
+#endif
     }
 
 }

--- a/WormUITests/Helpers/XCTest.swift
+++ b/WormUITests/Helpers/XCTest.swift
@@ -12,47 +12,26 @@ extension XCTestCase {
 
     // MARK: - Properties
 
-    /// The application under test instance with the `TEST` flag added to the launch environment.
-    @MainActor
-    static var testApp: XCUIApplication {
-        let app = XCUIApplication()
-        app.launchEnvironment = ["TEST": "YES"]
+    static let resetOnboardingEnvironmentKey = "RESET_ONBOARDING"
 
-        return app
-    }
+    // MARK: Private properties
+
+    static let testEnvironmentKey = "TEST"
 
     // MARK: - Methods
 
-    /// Removes the app from the testing device.
     @MainActor
-    func deleteApp() {
-        XCUIApplication().terminate()
+    static func makeTestApp(resetOnboarding: Bool = false) -> XCUIApplication {
+        let app = XCUIApplication()
 
-        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        let icon = springboard.icons["Worm"]
-        guard icon.exists else {
-            return
+        var environment = [testEnvironmentKey : "YES"]
+        if resetOnboarding {
+            environment[resetOnboardingEnvironmentKey] = "YES"
         }
 
-        icon.press(forDuration: 1.0)
+        app.launchEnvironment = environment
 
-        let removeAppButton = springboard.buttons["Remove App"]
-        guard removeAppButton.waitForExistence(timeout: 5.0) else {
-            return
-        }
-        removeAppButton.tap()
-
-        let deleteAppButton = springboard.buttons["Delete App"]
-        guard deleteAppButton.waitForExistence(timeout: 5.0) else {
-            return
-        }
-        deleteAppButton.tap()
-
-        let deleteButton = springboard.buttons["Delete"]
-        guard deleteButton.waitForExistence(timeout: 5.0) else {
-            return
-        }
-        deleteButton.tap()
+        return app
     }
 
 }

--- a/WormUITests/Tests/DetailsScreenTests.swift
+++ b/WormUITests/Tests/DetailsScreenTests.swift
@@ -55,7 +55,7 @@ final class BookDetailsViewUITests: XCTestCase {
 
     @MainActor
     private func openSearch() -> XCUIApplication {
-        let app = XCTestCase.testApp
+        let app = XCTestCase.makeTestApp()
         app.launch()
 
         let onboardingLabel = app.staticTexts["SearchOnboardingLabel"]

--- a/WormUITests/Tests/RecommendationsScreenTests.swift
+++ b/WormUITests/Tests/RecommendationsScreenTests.swift
@@ -8,22 +8,20 @@
 
 import XCTest
 
+@MainActor
 final class RecommendationsScreenTests: XCTestCase {
 
     // FIXME: Don't rely on hardcoded localizables.
 
     // MARK: - Methods
 
-    @MainActor
     func testScreenOpening() {
-        let app = openedRecommendationsTab()
+        let app = makeOpenRecommendationsTab()
         XCTAssert(app.staticTexts["Recommendations"].exists)
     }
 
-    @MainActor
     func testOnboarding_shown_onFirstLaunch() {
-        deleteApp()
-        let app = openedRecommendationsTab()
+        let app = makeOpenRecommendationsTab(resetOnboarding: true)
 
         let onboardingLabel = app.staticTexts["OnboardingLabel"]
         guard onboardingLabel.waitForExistence(timeout: 5.0) else {
@@ -35,10 +33,8 @@ final class RecommendationsScreenTests: XCTestCase {
         XCTAssertTrue(onboardingLabel.isHittable, "Onboarding isn't tappable.")
     }
 
-    @MainActor
     func testOnboarding_disappears_onTap() {
-        deleteApp()
-        let app = openedRecommendationsTab()
+        let app = makeOpenRecommendationsTab(resetOnboarding: true)
 
         let onboardingLabel = app.staticTexts["OnboardingLabel"]
         guard onboardingLabel.waitForExistence(timeout: 5.0) else {
@@ -54,10 +50,8 @@ final class RecommendationsScreenTests: XCTestCase {
         XCTAssertFalse(onboardingLabel.isHittable, "Oboarding is tappable.")
     }
 
-    @MainActor
     func testOnboarding_notShownTwice_afterDismissal() {
-        deleteApp()
-        let app = openedRecommendationsTab()
+        let app = makeOpenRecommendationsTab(resetOnboarding: true)
 
         let onboardingLabel = app.staticTexts["OnboardingLabel"]
         guard onboardingLabel.waitForExistence(timeout: 5.0) else {
@@ -72,7 +66,7 @@ final class RecommendationsScreenTests: XCTestCase {
         }
 
         app.terminate()
-        _ = openedRecommendationsTab()
+        _ = makeOpenRecommendationsTab()
 
         guard !onboardingLabel.waitForExistence(timeout: 5.0) else {
             XCTFail("Onboarding appeared again.")
@@ -80,21 +74,18 @@ final class RecommendationsScreenTests: XCTestCase {
         }
     }
 
-    @MainActor
     func testListInitiallyEmpty() {
-        let app = openedRecommendationsTab()
+        let app = makeOpenRecommendationsTab()
         XCTAssertTrue(app.tables.staticTexts.count == 0)
     }
 
-    @MainActor
     func testFiltersButton_isVisible() {
-        let app = openedRecommendationsTab()
+        let app = makeOpenRecommendationsTab()
         XCTAssertTrue(app.buttons["RecommendationsFiltersButton"].isHittable)
     }
 
-    @MainActor
     func testTopRatedButton_isVisible_whenFiltersButton_isTapped() {
-        let app = openedRecommendationsTab()
+        let app = makeOpenRecommendationsTab()
         app.buttons["RecommendationsFiltersButton"].tap()
 
         let topRatedButton = app.buttons["Top rated"]
@@ -105,9 +96,8 @@ final class RecommendationsScreenTests: XCTestCase {
 
     // MARK: Private properties
 
-    @MainActor
-    private func openedRecommendationsTab() -> XCUIApplication {
-        let app = XCTestCase.testApp
+    private func makeOpenRecommendationsTab(resetOnboarding: Bool = false) -> XCUIApplication {
+        let app = XCTestCase.makeTestApp(resetOnboarding: resetOnboarding)
         app.launch()
 
         let tabButton = app.tabBars.buttons["Recommendations"]

--- a/WormUITests/Tests/SearchScreenTests.swift
+++ b/WormUITests/Tests/SearchScreenTests.swift
@@ -8,17 +8,15 @@
 
 import XCTest
 
+@MainActor
 final class SearchScreenTests: XCTestCase {
 
     // FIXME: Don't rely on hardcoded localizables.
 
     // MARK: - Methods
 
-    @MainActor
     func testSearchOnboarding_shown_onFirstLaunch() {
-        deleteApp()
-
-        let app = XCTestCase.testApp
+        let app = XCTestCase.makeTestApp(resetOnboarding: true)
         app.launch()
 
         let onboardingLabel = app.staticTexts["SearchOnboardingLabel"]
@@ -31,11 +29,8 @@ final class SearchScreenTests: XCTestCase {
         XCTAssertTrue(onboardingLabel.isHittable, "Search onboarding isn't tappable.")
     }
 
-    @MainActor
     func testSearchOnboarding_disappears_onTap() {
-        deleteApp()
-
-        let app = XCTestCase.testApp
+        let app = XCTestCase.makeTestApp(resetOnboarding: true)
         app.launch()
 
         let onboardingLabel = app.staticTexts["SearchOnboardingLabel"]
@@ -52,11 +47,8 @@ final class SearchScreenTests: XCTestCase {
         XCTAssertFalse(onboardingLabel.isHittable, "Search onboarding is tappable.")
     }
 
-    @MainActor
     func testSearchOnboarding_shownTwice() {
-        deleteApp()
-
-        let app = XCTestCase.testApp
+        let app = XCTestCase.makeTestApp(resetOnboarding: true)
         app.launch()
 
         let onboardingLabel = app.staticTexts["SearchOnboardingLabel"]
@@ -80,11 +72,8 @@ final class SearchScreenTests: XCTestCase {
         }
     }
 
-    @MainActor
     func testRecommendationsOnboarding_appears_onSearchOnboarding_disappearing() {
-        deleteApp()
-
-        let app = XCTestCase.testApp
+        let app = XCTestCase.makeTestApp(resetOnboarding: true)
         app.launch()
 
         let searchOnboardingLabel = app.staticTexts["SearchOnboardingLabel"]
@@ -109,11 +98,8 @@ final class SearchScreenTests: XCTestCase {
         XCTAssertTrue(recommendationsOnboardingLabel.isHittable, "Recommendations onboarding isn't tappable.")
     }
 
-    @MainActor
     func testRecommendationsOnboarding_disappears_onTap() {
-        deleteApp()
-
-        let app = XCTestCase.testApp
+        let app = XCTestCase.makeTestApp(resetOnboarding: true)
         app.launch()
 
         let searchOnboardingLabel = app.staticTexts["SearchOnboardingLabel"]
@@ -139,11 +125,8 @@ final class SearchScreenTests: XCTestCase {
         XCTAssertFalse(recommendationsOnboardingLabel.isHittable, "Recommendations onboarding is tappable.")
     }
 
-    @MainActor
     func testSearchOnboarding_notShownTwice_afterRecommendationsOnboardingDismissal() {
-        deleteApp()
-
-        let app = XCTestCase.testApp
+        let app = XCTestCase.makeTestApp(resetOnboarding: true)
         app.launch()
 
         let searchOnboardingLabel = app.staticTexts["SearchOnboardingLabel"]
@@ -166,6 +149,7 @@ final class SearchScreenTests: XCTestCase {
         }
 
         app.terminate()
+        app.launchEnvironment.removeValue(forKey: XCTestCase.resetOnboardingEnvironmentKey)
         app.launch()
 
         guard !searchOnboardingLabel.waitForExistence(timeout: 5.0) else {
@@ -174,17 +158,15 @@ final class SearchScreenTests: XCTestCase {
         }
     }
 
-    @MainActor
     func testSearch_isPresent() {
-        let app = XCTestCase.testApp
+        let app = XCTestCase.makeTestApp()
         app.launch()
 
         XCTAssert(app.staticTexts["Search"].exists)
     }
 
-    @MainActor
     func testSearchBarVisible() {
-        let app = XCTestCase.testApp
+        let app = XCTestCase.makeTestApp()
         app.launch()
 
         let searchBar = app.navigationBars.searchFields.element(boundBy: 0)
@@ -197,9 +179,8 @@ final class SearchScreenTests: XCTestCase {
         XCTAssertTrue(searchBar.isHittable)
     }
 
-    @MainActor
     func testKeyboardActivation() {
-        let app = XCTestCase.testApp
+        let app = XCTestCase.makeTestApp()
         app.launch()
 
         let searchBar = app.navigationBars.searchFields.element(boundBy: 0)
@@ -214,9 +195,8 @@ final class SearchScreenTests: XCTestCase {
         waitForExpectations(timeout: 5.0)
     }
 
-    @MainActor
     func testCancelSearchButtonVisible() {
-        let app = XCTestCase.testApp
+        let app = XCTestCase.makeTestApp()
         app.launch()
 
         let searchBar = app.navigationBars.searchFields.element(boundBy: 0)
@@ -236,9 +216,8 @@ final class SearchScreenTests: XCTestCase {
         XCTAssertTrue(cancelButton.isHittable)
     }
 
-    @MainActor
     func testCancelButtonHidesKeyboard() {
-        let app = XCTestCase.testApp
+        let app = XCTestCase.makeTestApp()
         app.launch()
 
         let searchBar = app.navigationBars.searchFields.element(boundBy: 0)
@@ -265,9 +244,8 @@ final class SearchScreenTests: XCTestCase {
         waitForExpectations(timeout: 5.0)
     }
 
-    @MainActor
     func testResultsInitiallyEmpty() {
-        let app = XCTestCase.testApp
+        let app = XCTestCase.makeTestApp()
         app.launch()
 
         XCTAssertTrue(app.tables.staticTexts.count == 0)


### PR DESCRIPTION
## Summary

- `deleteApp()` uninstalled the app via Springboard's "Remove App"/"Delete App"/"Delete" flow just to reset onboarding-shown `UserDefaults` flags between test runs, matching those system buttons by their English labels – which breaks on any non-English simulator locale.
- Replaced it with a `RESET_ONBOARDING` launch-environment flag, checked in `OnboardingPersistentService` under `#if DEBUG`, that clears the two onboarding keys directly at launch. This removes the Springboard interaction (and its locale dependency) entirely, and the UI test suite runs noticeably faster without the uninstall/reinstall dance.
- `XCTestCase.testApp` became `XCTestCase.makeTestApp(resetOnboarding:)`. One test that reuses the same `XCUIApplication` instance across `terminate()`/`launch()` clears the flag before its second launch, since `launchEnvironment` is otherwise re-read on every `launch()` call.

## Notes for reviewers

- `testSearchOnboarding_shownTwice` was already failing intermittently on `master` before this change (a pre-existing `UserDefaults`-write-timing issue around `app.terminate()`, unrelated to Springboard matching) – left untouched, out of scope here.
- The `// FIXME: Don't rely on hardcoded localizables.` comments in `SearchScreenTests.swift`/`RecommendationsScreenTests.swift` still apply to other matchers (e.g. `app.buttons["Top rated"]`, `app.buttons["Close"]`) that match in-app elements by localizable label text rather than a stable accessibility identifier – a different, broader issue than the one this PR fixes, so the `FIXME`s stay.

## Test plan

- [x] `xcodebuild build` succeeds
- [x] Full `WormTests` suite passes (97/97)
- [x] Full `WormUITests` suite passes (21/21): `SearchScreenTests`, `RecommendationsScreenTests`, `BookDetailsViewUITests`