### PR TITLE
Rank down recommendations shared with a blocked book's similar list

### DIFF
--- a/Worm/Sources/Screens/Recommendations/RecommendationsModel.swift
+++ b/Worm/Sources/Screens/Recommendations/RecommendationsModel.swift
@@ -58,11 +58,11 @@ actor RecommendationsDefaultModel: RecommendationsModel {
     private let catalogService: CatalogService
     private let favoritesService: any FavoritesService
     private lazy var cancellables = Set<AnyCancellable>()
-    private var prioritizedRecommendations = OrderedDictionary<String, (book: Book, sourceIDs: Set<String>)>() {
+    private var prioritizedRecommendations = OrderedDictionary<String, RecommendationEntry>() {
         didSet {
             recommendations = prioritizedRecommendations
                 .values
-                .stableSorted { $0.sourceIDs.count > $1.sourceIDs.count }
+                .stableSorted { $0.rank > $1.rank }
                 .map { $0.book }
         }
     }
@@ -78,7 +78,7 @@ actor RecommendationsDefaultModel: RecommendationsModel {
         self.favoritesService = favoritesService
 
         Task { [weak self] in
-            await self?.bind(favoritesService: favoritesService)
+            await self?.bindFavoritesService(favoritesService)
         }
     }
 
@@ -98,18 +98,29 @@ actor RecommendationsDefaultModel: RecommendationsModel {
 
     func blockFromRecommendationsBook(withID id: String) async {
         prioritizedRecommendations.removeValue(forKey: id)
+
         await favoritesService.addToBlockedBook(withID: id)
+        await applyPenalty(fromBlockedBookWithID: id)
     }
 
     // MARK: Private methods
 
-    private func bind(favoritesService: any FavoritesService) async {
+    private func bindFavoritesService(_ favoritesService: any FavoritesService) async {
         await favoritesService
             .favoriteBookIDsPublisher
             .removeDuplicates()
             .sink { @Sendable ids in
                 Task { [weak self] in
                     await self?.update(with: ids)
+                }
+            }
+            .store(in: &cancellables)
+        await favoritesService
+            .blockedBookIDsPublisher
+            .removeDuplicates()
+            .sink { @Sendable ids in
+                Task { [weak self] in
+                    await self?.applyPenalties(fromBlockedBookIDs: ids)
                 }
             }
             .store(in: &cancellables)
@@ -146,28 +157,78 @@ actor RecommendationsDefaultModel: RecommendationsModel {
         // This needs re-checking, because the situation might've changed while the book was being fetched.
         if await favoritesService.blockedBookIDs.contains(id) {
             prioritizedRecommendations.removeValue(forKey: id)
-        } else {
-            var sourceIDs = prioritizedRecommendations[id]?.sourceIDs ?? []
-            sourceIDs.insert(sourceID)
+            return
+        }
 
-            prioritizedRecommendations[id] = (book, sourceIDs)
+        if var entry = prioritizedRecommendations[id] {
+            entry.sourceIDs.insert(sourceID)
+            prioritizedRecommendations[id] = entry
+        } else {
+            let penalizingIDs = await penalizingBookIDs(forBookWithID: id)
+            prioritizedRecommendations[id] = RecommendationEntry(
+                book: book, penalizingIDs: penalizingIDs, sourceIDs: [sourceID]
+            )
         }
     }
 
     private func removeRecommendedBooksForBook(withID id: String) {
-        for bookDescriptor in prioritizedRecommendations {
-            var sourceIDs = bookDescriptor.value.sourceIDs
-            guard sourceIDs.contains(id) else {
+        for element in prioritizedRecommendations {
+            guard element.value.sourceIDs.contains(id) else {
                 continue
             }
 
-            if sourceIDs.count == 1 {
-                prioritizedRecommendations.removeValue(forKey: bookDescriptor.key)
+            if element.value.sourceIDs.count == 1 {
+                prioritizedRecommendations.removeValue(forKey: element.key)
             } else {
-                sourceIDs.remove(id)
-                prioritizedRecommendations[bookDescriptor.key] = (bookDescriptor.value.book, sourceIDs)
+                var entry = element.value
+                entry.sourceIDs.remove(id)
+
+                prioritizedRecommendations[element.key] = entry
             }
         }
+    }
+
+    private func applyPenalties(fromBlockedBookIDs blockedBookIDs: Set<String>) async {
+        for blockedBookID in blockedBookIDs {
+            await applyPenalty(fromBlockedBookWithID: blockedBookID)
+        }
+    }
+
+    private func applyPenalty(fromBlockedBookWithID blockedBookID: String) async {
+        let similarBookIDs = await catalogService.getBook(by: blockedBookID)?.similarBookIDs ?? []
+        for candidateID in similarBookIDs {
+            guard var entry = prioritizedRecommendations[candidateID] else {
+                continue
+            }
+
+            entry.penalizingIDs.insert(blockedBookID)
+            prioritizedRecommendations[candidateID] = entry
+        }
+    }
+
+    private func penalizingBookIDs(forBookWithID candidateID: String) async -> Set<String> {
+        var penalizingIDs = Set<String>()
+        for blockedBookID in await favoritesService.blockedBookIDs {
+            let similarBookIDs = await catalogService.getBook(by: blockedBookID)?.similarBookIDs ?? []
+            if similarBookIDs.contains(candidateID) {
+                penalizingIDs.insert(blockedBookID)
+            }
+        }
+
+        return penalizingIDs
+    }
+
+    // MARK: -
+
+    private struct RecommendationEntry {
+
+        // MARK: - Properties
+
+        let book: Book
+        var penalizingIDs = Set<String>()
+        var rank: Int { sourceIDs.count - penalizingIDs.count }
+        var sourceIDs: Set<String>
+
     }
 
 }

--- a/WormTests/Mocks/FavoritesMockService.swift
+++ b/WormTests/Mocks/FavoritesMockService.swift
@@ -18,14 +18,15 @@ actor FavoritesMockService: FavoritesService {
     var blockedBookIDsPublisher: Published<Set<String>>.Publisher { $blockedBookIDs }
     var favoriteBookIDsPublisher: Published<Set<String>>.Publisher { $favoriteBookIDs }
     @Published
-    private(set) var blockedBookIDs = Set<String>()
+    private(set) var blockedBookIDs: Set<String>
     @Published
     private(set) var favoriteBookIDs: Set<String>
 
     // MARK: - Initialization
 
-    init(favoriteBookIDs: Set<String> = []) async {
+    init(favoriteBookIDs: Set<String> = [], blockedBookIDs: Set<String> = []) async {
         self.favoriteBookIDs = favoriteBookIDs
+        self.blockedBookIDs = blockedBookIDs
     }
 
     // MARK: - Methods

--- a/WormTests/Tests/Screens/Recommendations/RecommendationsDefaultModelTests.swift
+++ b/WormTests/Tests/Screens/Recommendations/RecommendationsDefaultModelTests.swift
@@ -255,4 +255,138 @@ struct RecommendationsDefaultModelTests {
         await #expect(favoritesService.blockedBookIDs.contains(id))
     }
 
+    @Test(.timeLimit(.minutes(1)))
+    func recommendationsUpdate_ordersBooks_byNumberOfRecommendingFavorites() async {
+        let firstFavorite = Book(
+            id: "1",
+            authors: ["Author"],
+            title: "First Favorite",
+            description: "Desc1",
+            similarBookIDs: [
+                "100",
+                "200"
+            ]
+        )
+        let secondFavorite = Book(
+            id: "2", authors: ["Author"], title: "Second Favorite", description: "Desc2", similarBookIDs: ["100"]
+        )
+
+        let higherRanked = Book(id: "100", authors: ["Author"], title: "Higher Ranked", description: "Desc3")
+        let lowerRanked = Book(id: "200", authors: ["Author"], title: "Lower Ranked", description: "Desc4")
+
+        let model: RecommendationsModel = await RecommendationsDefaultModel(
+            catalogService: CatalogMockService(
+                books: [
+                    firstFavorite,
+                    secondFavorite,
+                    higherRanked,
+                    lowerRanked
+                ]
+            ),
+            favoritesService: FavoritesMockService(
+                favoriteBookIDs: [
+                    firstFavorite.id,
+                    secondFavorite.id
+                ]
+            )
+        )
+
+        while await model.recommendations != [
+            higherRanked,
+            lowerRanked
+        ] {
+            await Task.yield()
+        }
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func recommendationsUpdate_lowersRank_ofBooksRecommendedByBlockedBook() async {
+        let favorite = Book(
+            id: "1",
+            authors: ["Author"],
+            title: "Favorite",
+            description: "Desc1",
+            similarBookIDs: [
+                "100",
+                "200",
+                "300"
+            ]
+        )
+        let blockedRecommendation = Book(
+            id: "100", authors: ["Author"], title: "Blocked", description: "Desc2", similarBookIDs: ["200"]
+        )
+
+        let penalizedRecommendation = Book(id: "200", authors: ["Author"], title: "Penalized", description: "Desc3")
+        let unaffectedRecommendation = Book(id: "300", authors: ["Author"], title: "Unaffected", description: "Desc4")
+
+        let model: RecommendationsModel = await RecommendationsDefaultModel(
+            catalogService: CatalogMockService(
+                books: [
+                    favorite,
+                    blockedRecommendation,
+                    penalizedRecommendation,
+                    unaffectedRecommendation
+                ]
+            ),
+            favoritesService: FavoritesMockService(favoriteBookIDs: [favorite.id])
+        )
+
+        while await model.recommendations != [
+            blockedRecommendation,
+            penalizedRecommendation,
+            unaffectedRecommendation
+        ] {
+            await Task.yield()
+        }
+
+        await model.blockFromRecommendationsBook(withID: blockedRecommendation.id)
+        while await model.recommendations != [
+            unaffectedRecommendation,
+            penalizedRecommendation
+        ] {
+            await Task.yield()
+        }
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func recommendationsUpdate_appliesAlreadyBlockedBooksPenalty_toNewlyAddedRecommendation() async {
+        let alreadyBlocked = Book(
+            id: "1", authors: ["Author"], title: "Already Blocked", description: "Desc1", similarBookIDs: ["200"]
+        )
+        let favorite = Book(
+            id: "2",
+            authors: ["Author"],
+            title: "Favorite",
+            description: "Desc2",
+            similarBookIDs: [
+                "200",
+                "300"
+            ]
+        )
+
+        let penalizedRecommendation = Book(id: "200", authors: ["Author"], title: "Penalized", description: "Desc3")
+        let unaffectedRecommendation = Book(id: "300", authors: ["Author"], title: "Unaffected", description: "Desc4")
+
+        let model: RecommendationsModel = await RecommendationsDefaultModel(
+            catalogService: CatalogMockService(
+                books: [
+                    alreadyBlocked,
+                    favorite,
+                    penalizedRecommendation,
+                    unaffectedRecommendation
+                ]
+            ),
+            favoritesService: FavoritesMockService(
+                favoriteBookIDs: [favorite.id], blockedBookIDs: [alreadyBlocked.id]
+            )
+        )
+
+        while await model.recommendations != [
+            unaffectedRecommendation,
+            penalizedRecommendation
+        ] {
+            await Task.yield()
+        }
+    }
+
 }

--- a/WormTests/Tests/Screens/Recommendations/RecommendationsDefaultViewModelTests.swift
+++ b/WormTests/Tests/Screens/Recommendations/RecommendationsDefaultViewModelTests.swift
@@ -12,11 +12,11 @@ import Testing
 @testable
 import Worm
 
+@MainActor
 struct RecommendationsDefaultViewModelTests {
 
     // MARK: - Methods
 
-    @MainActor
     @Test
     func recommendationsOnboarding_stateInitially_asProvided() async {
         let value = true
@@ -28,7 +28,6 @@ struct RecommendationsDefaultViewModelTests {
         #expect(vm.onboardingShown == value, "Onboarding has an unexpected initial value.")
     }
 
-    @MainActor
     @Test(.timeLimit(.minutes(1)))
     func recommendationsOnboarding_update_updatesPersistence() async {
         let value = true
@@ -45,7 +44,6 @@ struct RecommendationsDefaultViewModelTests {
         }
     }
 
-    @MainActor
     @Test
     func recommendations_empty_initially() async {
         let vm: any RecommendationsViewModel = await RecommendationsDefaultViewModel(
@@ -56,7 +54,6 @@ struct RecommendationsDefaultViewModelTests {
         #expect(vm.recommendations.isEmpty)
     }
 
-    @MainActor
     @Test(.timeLimit(.minutes(1)))
     func recommendations_update() async {
         let recommendations = [Book(id: "1", authors: [], title: "", description: "Desc")]
@@ -73,7 +70,6 @@ struct RecommendationsDefaultViewModelTests {
         }
     }
 
-    @MainActor
     @Test(.timeLimit(.minutes(1)))
     func recommendations_update_afterTogglingFavorite() async {
         let id = "1"
@@ -90,7 +86,6 @@ struct RecommendationsDefaultViewModelTests {
         }
     }
 
-    @MainActor
     @Test(.timeLimit(.minutes(1)))
     func togglingFavorite_updatesModel() async {
         let model = await RecommendationsMockModel()
@@ -108,7 +103,6 @@ struct RecommendationsDefaultViewModelTests {
         }
     }
 
-    @MainActor
     @Test
     func detailsViewModel_authors_accordingToBook() async {
         let authors = [
@@ -130,7 +124,6 @@ struct RecommendationsDefaultViewModelTests {
         #expect(detailsVM.authors == "Author 1, Authors 2", "Unexpected authors string")
     }
 
-    @MainActor
     @Test
     func detailsViewModel_title_accordingToBook() async {
         let title = "Title"
@@ -157,7 +150,6 @@ struct RecommendationsDefaultViewModelTests {
         #expect(detailsVM.title == "Title", "Unexpected title string")
     }
 
-    @MainActor
     @Test
     func detailsViewModel_createsRatingViewModel_withRating_accordingToBook() async {
         let bookVM = BookViewModel(
@@ -184,7 +176,6 @@ struct RecommendationsDefaultViewModelTests {
         #expect(detailsVM.ratingViewModel?.rating == 1.23, "Unexpected rating string")
     }
 
-    @MainActor
     @Test(.timeLimit(.minutes(1)))
     func blockingRecommendation_updatesModel() async {
         let model = await RecommendationsMockModel()
@@ -203,7 +194,6 @@ struct RecommendationsDefaultViewModelTests {
         }
     }
 
-    @MainActor
     @Test
     func appliedFilters_empty_initially() async {
         let vm: any RecommendationsViewModel = await RecommendationsDefaultViewModel(
@@ -214,7 +204,25 @@ struct RecommendationsDefaultViewModelTests {
         #expect(vm.appliedFilters.isEmpty)
     }
 
-    @MainActor
+    @Test(.timeLimit(.minutes(1)))
+    func recommendations_preservesOrder_fromModel() async {
+        let books = [
+            Book(id: "1", authors: [], title: "First", description: "Desc1"),
+            Book(id: "2", authors: [], title: "Second", description: "Desc2"),
+            Book(id: "3", authors: [], title: "Third", description: "Desc3")
+        ]
+        let vm: any RecommendationsViewModel = await RecommendationsDefaultViewModel(
+            model: RecommendationsMockModel(recommendations: books),
+            onboardingService: OnboardingMockService(),
+            imageService: ImageMockService()
+        )
+
+        let expected = books.map { BookViewModel(book: $0, favorite: false) }
+        while vm.recommendations != expected {
+            await Task.yield()
+        }
+    }
+
     @Test
     func recommendations_update_whenAppliedFilters_change() async {
         let book = Book(id: "1", authors: [], title: "", description: "Desc", rating: 3.0)


### PR DESCRIPTION
## Summary

- Blocking a recommendation removed only that one book and excluded it from ever reappearing, but had no effect on the ranking of other recommendations – even when the blocked book's own similar-books list also recommended them.
- Adds a `penalizingIDs` set to each recommendation entry, mirroring the existing `sourceIDs` (favourites recommending it): for every blocked book, each book on *its* similar-books list gets a -1 penalty. Rank is now `sourceIDs.count - penalizingIDs.count` (previously just `sourceIDs.count`).
- Example: a book recommended by 3 favorites (rank 3) gets blocked. Every other current recommendation that book's own similar-books list points to drops by 1.
- Penalties are derived from the already-persisted blocked-books list (via `blockedBookIDsPublisher`, mirroring the existing `favoriteBookIDsPublisher` subscription) rather than applied as a one-off mutation, so they survive app restarts and correctly reapply if a penalised book temporarily drops out of the list and later reappears.

## Test plan

- [x] Full `WormTests` suite passes (101/101), including 3 new Model tests (rank ordering, block-time penalty propagation, penalty backfill for newly (re-)added recommendations) and 1 new ViewModel test (order preservation through the VM's map/filter pipeline)
- [x] Verified both new-behaviour Model tests actually catch the bug: reverted the production change, confirmed both fail, restored and confirmed green
- No UI test: the shared `Book.previewFixtures` graph (used across Search/Favourites/Recommendations UI tests) is a simple 1-to-1 pairing with no overlapping similar-lists, so there's nothing to exercise a rank change against without restructuring shared fixtures used elsewhere. Model-level tests assert exact ordering deterministically, which is the more precise way to verify this anyway.