### PR TITLE
Remove stale TODO about book image not updating on download

### DIFF
--- a/Worm/Sources/Screens/Details/BookDetailsView.swift
+++ b/Worm/Sources/Screens/Details/BookDetailsView.swift
@@ -22,7 +22,7 @@ struct BookDetailsView<ViewModel: BookDetailsViewModel>: View {
                     .padding()
             }
             ScrollView {
-                if let image = viewModel.image { // TODO: Update if downloaded later.
+                if let image = viewModel.image {
                     Image(decorative: image, scale: 1.0)
                         .padding(.bottom)
                 }


### PR DESCRIPTION
## Summary

`BookDetailsView.swift:25` had `// TODO: Update if downloaded later.` implying the image doesn't refresh once it finishes downloading. `BookDetailsDefaultViewModel.image` has been `@Published` since it was first introduced (predates the SwiftUI/MVVM migration), and the view already re-renders reactively via `@ObservedObject` when it arrives. No actual gap found – removing the stale comment.

## Test plan

- [x] \`xcodebuild build\` succeeds