### PR TITLE
Localize the joined authors list

### DIFF
--- a/Worm/Sources/Screens/BookViewModel.swift
+++ b/Worm/Sources/Screens/BookViewModel.swift
@@ -81,7 +81,7 @@ extension BookViewModel {
     init(book: Book, favorite: Bool) {
         self.init(
             id: book.id,
-            authors: book.authors.joined(separator: ", "), // TODO: Localize.
+            authors: ListFormatter.localizedString(byJoining: book.authors),
             title: book.title,
             description: book.description,
             imageURL: book.imageURL,

--- a/WormTests/Tests/Screens/BookViewModelTests.swift
+++ b/WormTests/Tests/Screens/BookViewModelTests.swift
@@ -57,7 +57,7 @@ struct BookViewModelTests {
         )
 
         let vm = BookViewModel(book: book, favorite: true)
-        #expect(vm.authors == "\(author1), \(author2)")
+        #expect(vm.authors == ListFormatter.localizedString(byJoining: [author1, author2]))
     }
 
     @Test

--- a/WormTests/Tests/Screens/Recommendations/RecommendationsDefaultViewModelTests.swift
+++ b/WormTests/Tests/Screens/Recommendations/RecommendationsDefaultViewModelTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Foundation
 import GoodreadsService
 import SwiftUI
 import Testing
@@ -121,7 +122,7 @@ struct RecommendationsDefaultViewModelTests {
         )
         let detailsVM = vm.makeDetailsViewModel(for: bookVM)
 
-        #expect(detailsVM.authors == "Author 1, Authors 2", "Unexpected authors string")
+        #expect(detailsVM.authors == ListFormatter.localizedString(byJoining: authors), "Unexpected authors string")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `BookViewModel.swift:84` had `// TODO: Localize.` on `book.authors.joined(separator: ", ")`. Swapped for `ListFormatter.localizedString(byJoining:)`, so multi-author lists format per the device's locale (e.g. "A, B, and C" in English) instead of a hardcoded comma join.
- Fixes both the visible authors line and the accessibility label that reuses it (`BookListCell`).
- Two tests hardcoded the old literal format; updated them to compare against `ListFormatter`'s own output instead of a guessed string, so they stay correct regardless of locale.

## Test plan

- [x] \`xcodebuild build\` succeeds
- [x] Full \`WormTests\` suite passes
- [x] Verified the change is real: reverted the production line alone, confirmed both updated tests fail ("Author1, Author2" vs "Author1 and Author2"), then restored and confirmed green