### PR TITLE
Make in-app UI test matchers locale-robust

### DIFF
--- a/Worm/Sources/Screens/Main/MainScreen.swift
+++ b/Worm/Sources/Screens/Main/MainScreen.swift
@@ -33,6 +33,7 @@ struct MainScreen<
             }
                 .tabItem {
                     Label("Search", systemImage: "magnifyingglass")
+                        .accessibilityIdentifier("SearchTabButton")
                 }
             NavigationStack {
                 recommendationsView
@@ -40,6 +41,7 @@ struct MainScreen<
             }
                 .tabItem {
                     Label("Recommendations", systemImage: "checkmark")
+                        .accessibilityIdentifier("RecommendationsTabButton")
                 }
             NavigationStack {
                 favoritesView
@@ -47,6 +49,7 @@ struct MainScreen<
             }
                 .tabItem {
                     Label("Favorites", systemImage: "heart")
+                        .accessibilityIdentifier("FavoritesTabButton")
                 }
         }
     }

--- a/Worm/Sources/Screens/Recommendations/Filters/FiltersView.swift
+++ b/Worm/Sources/Screens/Recommendations/Filters/FiltersView.swift
@@ -25,6 +25,10 @@ struct FiltersView<ViewModel: FiltersViewModel>: View {
 #endif
         LazyVGrid(columns: [GridItem(.adaptive(minimum: 100.0))], spacing: 20.0) {
             ForEach(RecommendationsFilter.allCases, id: \.self) { filterItem in
+                let identifier = switch filterItem {
+                    case .topRated:
+                        "TopRatedFilterButton"
+                }
                 Button {
                     withAnimation {
                         if viewModel.appliedFilters.contains(filterItem) {
@@ -39,14 +43,15 @@ struct FiltersView<ViewModel: FiltersViewModel>: View {
                             Text("Top rated", comment: "A title for the Top Rated filter")
                     }
                 }
-                .`if`(viewModel.appliedFilters.contains(filterItem)) {
-                    $0
-                        .buttonStyle(.borderedProminent)
-                } `else`: {
-                    $0
-                        .buttonStyle(.bordered)
-                }
-                .buttonBorderShape(.capsule)
+                    .accessibilityIdentifier(identifier)
+                    .`if`(viewModel.appliedFilters.contains(filterItem)) {
+                        $0
+                            .buttonStyle(.borderedProminent)
+                    } `else`: {
+                        $0
+                            .buttonStyle(.bordered)
+                    }
+                    .buttonBorderShape(.capsule)
             }
         }
             .padding(32.0)

--- a/WormUITests/Helpers/XCTest.swift
+++ b/WormUITests/Helpers/XCTest.swift
@@ -31,6 +31,13 @@ extension XCTestCase {
 
         app.launchEnvironment = environment
 
+        app.launchArguments += [
+            "-AppleLanguages", 
+            "(en)",
+            "-AppleLocale",
+            "en_US"
+        ]
+
         return app
     }
 

--- a/WormUITests/Tests/DetailsScreenTests.swift
+++ b/WormUITests/Tests/DetailsScreenTests.swift
@@ -26,8 +26,7 @@ final class BookDetailsViewUITests: XCTestCase {
 
         bookCell.tap()
 
-        let ratingView = app.otherElements["4,6 out of 5 stars"]
-        print(app.debugDescription)
+        let ratingView = app.otherElements["4.6 out of 5 stars"]
         XCTAssertTrue(ratingView.exists, "Rating view should be displayed for books with ratings.")
     }
 
@@ -44,9 +43,10 @@ final class BookDetailsViewUITests: XCTestCase {
         }
 
         bookCell.tap()
-        if app.otherElements.allElementsBoundByIndex.first(
-            where: { $0.label.matches("\\d,\\d out of 5 stars") }
-        ) != nil {
+        if app
+            .otherElements
+            .allElementsBoundByIndex
+            .first(where: { $0.label.matches("\\d\\.\\d out of 5 stars") }) != nil {
             XCTFail("Rating view should not be displayed for books without ratings.")
         }
     }

--- a/WormUITests/Tests/RecommendationsScreenTests.swift
+++ b/WormUITests/Tests/RecommendationsScreenTests.swift
@@ -11,13 +11,11 @@ import XCTest
 @MainActor
 final class RecommendationsScreenTests: XCTestCase {
 
-    // FIXME: Don't rely on hardcoded localizables.
-
     // MARK: - Methods
 
     func testScreenOpening() {
         let app = makeOpenRecommendationsTab()
-        XCTAssert(app.staticTexts["Recommendations"].exists)
+        XCTAssert(app.buttons["RecommendationsFiltersButton"].exists)
     }
 
     func testOnboarding_shown_onFirstLaunch() {
@@ -88,9 +86,9 @@ final class RecommendationsScreenTests: XCTestCase {
         let app = makeOpenRecommendationsTab()
         app.buttons["RecommendationsFiltersButton"].tap()
 
-        let topRatedButton = app.buttons["Top rated"]
-        XCTAssertTrue(app.waitForExistence(timeout: 5.0))
+        let topRatedButton = app.buttons["TopRatedFilterButton"]
 
+        XCTAssertTrue(topRatedButton.waitForExistence(timeout: 5.0))
         XCTAssertTrue(topRatedButton.isHittable)
     }
 
@@ -100,7 +98,7 @@ final class RecommendationsScreenTests: XCTestCase {
         let app = XCTestCase.makeTestApp(resetOnboarding: resetOnboarding)
         app.launch()
 
-        let tabButton = app.tabBars.buttons["Recommendations"]
+        let tabButton = app.tabBars.buttons["RecommendationsTabButton"]
         tabButton.tap()
 
         return app

--- a/WormUITests/Tests/SearchScreenTests.swift
+++ b/WormUITests/Tests/SearchScreenTests.swift
@@ -11,8 +11,6 @@ import XCTest
 @MainActor
 final class SearchScreenTests: XCTestCase {
 
-    // FIXME: Don't rely on hardcoded localizables.
-
     // MARK: - Methods
 
     func testSearchOnboarding_shown_onFirstLaunch() {
@@ -162,7 +160,7 @@ final class SearchScreenTests: XCTestCase {
         let app = XCTestCase.makeTestApp()
         app.launch()
 
-        XCTAssert(app.staticTexts["Search"].exists)
+        XCTAssert(app.navigationBars.searchFields.element(boundBy: 0).exists)
     }
 
     func testSearchBarVisible() {


### PR DESCRIPTION
## Summary

Closes the remaining half of the "Don't rely on hardcoded localisables." FIXMEs in \`SearchScreenTests.swift\`/\`RecommendationsScreenTests.swift\` (the other half – Springboard app-deletion matching – was fixed earlier in #38).

Two distinct problems here:
- Several matchers keyed off our **own** localised display text (nav titles, the Top Rated filter button, tab bar items).
- Two matchers keyed off **Apple's own system** search-cancel button, whose label is sourced from Apple's own localisation, not ours – confirmed by inspecting the accessibility tree (no \`Button("Close")\` exists anywhere near search in our code).

Fixes:
- Added \`.accessibilityIdentifier\` to the elements we control: \`MainScreen\`'s three tab items (\`SearchTabButton\`/\`RecommendationsTabButton\`/\`FavoritesTabButton\`) and the Top Rated filter button (\`TopRatedFilterButton\`); matchers updated to use those instead of display text. \`testSearch_isPresent\` switched to a type-based query already used elsewhere in the same file.
- For Apple's own component (which we can't tag with our own identifier), pinned the test app's own language/region via \`-AppleLanguages (en) -AppleLocale en_US\` launch arguments in \`makeTestApp()\`. It renders in-process, so this makes it deterministic too – and this same pin also covers our own text as a second line of defence, on top of the identifiers.
- Pinning the locale surfaced a real, unrelated pre-existing test bug: the rating accessibility-label test hardcoded a comma decimal separator ("4,6 out of 5 stars"), which only ever matched under a comma-decimal locale. Fixed to the English period format ("4.6 out of 5 stars") now that the language is pinned, and fixed the sibling negative-check RegEx the same way. Also dropped a stray leftover \`print(app.debugDescription)\` sitting on the line right above it.

## Test plan
- [x] \`xcodebuild build\` succeeds
- [x] Full \`WormUITests\` suite passes (21/21)
- [x] Full \`WormTests\` suite passes (unaffected)

## Note for follow-up
\`MainScreenTests.swift\` (#42, not yet merged) matches tabs by the same localised text this PR fixes elsewhere – it'll want the new tab identifiers too once merged. Not touched here since it's on a separate branch.