### PR TITLE
Recover from a corrupted SwiftData store instead of crashing at launch

### DIFF
--- a/Worm/Sources/Service/ModelContainerFactory.swift
+++ b/Worm/Sources/Service/ModelContainerFactory.swift
@@ -1,0 +1,47 @@
+//
+//  ModelContainerFactory.swift
+//  Worm
+//
+//  Created by Lazarev-Zubov, Nikita on 21.7.2026.
+//
+
+import Foundation
+import SwiftData
+
+/// Creates `ModelContainer`s, recovering from an unreadable on-disk store.
+enum ModelContainerFactory {
+
+    // MARK: - Methods
+
+    /// Creates a model container for the given schema and configuration.
+    ///
+    /// If the store is unreadable (e.g. corrupted), its files are removed and creation is retried once, accepting the
+    ///   data loss rather than leaving the caller permanently unable to proceed.
+    ///
+    /// - Parameters:
+    ///   - schema: The schema of the container to create.
+    ///   - configuration: The configuration of the container to create.
+    /// - Returns: The created model container.
+    /// - Throws: Whatever `ModelContainer`'s initializer throws, if creation still fails after the store is reset.
+    static func make(for schema: Schema, configuration: ModelConfiguration) throws -> ModelContainer {
+        do {
+            return try ModelContainer(for: schema, configurations: configuration)
+        } catch {
+            removeStoreFiles(at: configuration.url)
+            return try ModelContainer(for: schema, configurations: configuration)
+        }
+    }
+
+    // MARK: Private methods
+
+    private static func removeStoreFiles(at url: URL) {
+        for suffix in [
+            "",
+            "-shm",
+            "-wal"
+        ] {
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: url.path + suffix))
+        }
+    }
+
+}

--- a/Worm/WormApp.swift
+++ b/Worm/WormApp.swift
@@ -56,11 +56,11 @@ struct WormApp: App {
                 version: Schema.Version(1, 0, 0)
             )
             let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: storedInMemory)
+
             do {
-                return try ModelContainer(for: schema, configurations: configuration)
+                return try ModelContainerFactory.make(for: schema, configuration: configuration)
             } catch {
-                // TODO: Proper error handling.
-                fatalError("Could not create ModelContainer: \(error)")
+                fatalError("Could not create ModelContainer, even after resetting the store: \(error)")
             }
         }()
         return FavoritesPersistenceService(modelContainer: modelContainer)

--- a/WormTests/Tests/Service/ModelContainerFactoryTests.swift
+++ b/WormTests/Tests/Service/ModelContainerFactoryTests.swift
@@ -1,0 +1,60 @@
+//
+//  ModelContainerFactoryTests.swift
+//  WormTests
+//
+//  Created by Lazarev-Zubov, Nikita on 21.7.2026.
+//
+
+import Foundation
+import SwiftData
+import Testing
+@testable
+import Worm
+
+struct ModelContainerFactoryTests {
+
+    // MARK: - Properties
+
+    // MARK: Private properties
+
+    private var storeURL: URL { FileManager.default.temporaryDirectory.appending(path: "\(UUID().uuidString).store") }
+
+    // MARK: - Methods
+
+    @Test
+    func make_returnsContainer_whenStoreIsValid() throws {
+        let url = storeURL
+        defer { removeStoreFiles(at: url) }
+
+        let schema = Schema([FavoriteBook.self])
+        let configuration = ModelConfiguration(schema: schema, url: url)
+
+        _ = try ModelContainerFactory.make(for: schema, configuration: configuration)
+    }
+
+    @Test
+    func make_recoversFromCorruptedStore() throws {
+        let url = storeURL
+        defer { removeStoreFiles(at: url) }
+
+        try Data("Not a valid SQLite store.".utf8).write(to: url)
+
+        let schema = Schema([FavoriteBook.self])
+        let configuration = ModelConfiguration(schema: schema, url: url)
+
+        _ = try ModelContainerFactory.make(for: schema, configuration: configuration)
+    }
+
+    // MARK: Private methods
+
+    private func removeStoreFiles(at url: URL) {
+        for suffix in [
+            "",
+            "-shm",
+            "-wal"
+        ] {
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: url.path + suffix))
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

- `WormApp.swift` had `// TODO: Proper error handling.` on a `fatalError` triggered when `ModelContainer` creation fails (e.g., an unreadable/corrupted on-disk store) – this permanently bricks the app on launch, with no recovery path.
- Extracted creation into `ModelContainerFactory.make(for:configuration:)`, a small standalone unit: on the first failure, removes the store's files (`.store`/`-shm`/`-wal`) and retries once, accepting the data loss (lost favourites/blocked list) rather than leaving the app permanently unusable. Only `fatalError`s if the retry also fails.

## Test plan

- [x] `xcodebuild build` succeeds
- [x] New `ModelContainerFactoryTests`: one confirms the happy path still works, one genuinely corrupts a store on disk (writes garbage bytes to the file) and confirms recovery succeeds
- [x] Verified the corrupted-store test is meaningful: temporarily stripped the retry logic, confirmed it fails, restored and confirmed green
- [x] Full `WormTests` suite passes (103/103)