### PR TITLE
Fix accessibility issues found in static audit

### DIFF
--- a/Worm/Resources/Localizable.xcstrings
+++ b/Worm/Resources/Localizable.xcstrings
@@ -145,6 +145,23 @@
         }
       }
     },
+    "Filters" : {
+      "comment" : "Accessibility label for the button that opens the recommendations filters.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filters"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фильтры"
+          }
+        }
+      }
+    },
     "OK" : {
       "comment" : "A button that dismisses an alert.",
       "localizations" : {

--- a/Worm/Sources/Extensions/View.swift
+++ b/Worm/Sources/Extensions/View.swift
@@ -31,4 +31,34 @@ extension View {
         }
     }
 
+    /// Positions this view within an invisible frame having the specified size constraints.
+    /// - Parameters:
+    ///   - minSize: The minimum width and height of the resulting frame.
+    ///   - idealWidth: The ideal width of the resulting frame.
+    ///   - maxWidth: The maximum width of the resulting frame.
+    ///   - idealHeight: The ideal height of the resulting frame.
+    ///   - maxHeight: The maximum height of the resulting frame.
+    ///   - alignment: The alignment of this view inside the resulting frame. Note that most alignment values have no
+    ///     apparent effect when the size of the frame happens to match that of this view.
+    /// - Returns: A view with flexible dimensions given by the call’s non-`nil` parameters.
+    @inlinable
+    nonisolated public func frame(
+        minSize: CGFloat,
+        idealWidth: CGFloat? = nil,
+        maxWidth: CGFloat? = nil,
+        idealHeight: CGFloat? = nil,
+        maxHeight: CGFloat? = nil,
+        alignment: Alignment = .center
+    ) -> some View {
+        frame(
+            minWidth: minSize,
+            idealWidth: idealWidth,
+            maxWidth: maxWidth,
+            minHeight: minSize,
+            idealHeight: idealHeight,
+            maxHeight: maxHeight,
+            alignment: alignment
+        )
+    }
+
 }

--- a/Worm/Sources/Extensions/View.swift
+++ b/Worm/Sources/Extensions/View.swift
@@ -11,27 +11,6 @@ extension View {
 
     // MARK: - Methods
 
-    /// Checks a condition and applies a view modification only if the condition is met.
-    /// - Parameters:
-    ///   - condition: The condition to met.
-    ///   - transform: The view modification to apply.
-    ///   - alternativeTransform: The modification to apply, if the condition is not met. If not provided, the original, unmodified view will be returned.
-    /// - Returns: The view with the applied modification, if the condition is met, or the original view, if it isn't.
-    @ViewBuilder
-    func `if`<Transform: View, AlternativeTransform: View>(
-        _ condition: Bool,
-        transform: (Self) -> Transform,
-        else alternativeTransform: ((Self) -> AlternativeTransform)? = nil
-    ) -> some View {
-        if condition {
-            transform(self)
-        } else if let alternativeTransform {
-            alternativeTransform(self)
-        } else {
-            self
-        }
-    }
-
     /// Shows a standard alert reporting that a change couldn't be saved, while the given condition is `true`.
     /// - Parameters:
     ///   - isPresented: Whether the alert is shown.

--- a/Worm/Sources/Screens/Cell/BookListCell.swift
+++ b/Worm/Sources/Screens/Cell/BookListCell.swift
@@ -38,6 +38,8 @@ struct BookListCell: View {
                                        ? "heart.fill"
                                        : "heart"))
                     .foregroundColor(.primary)
+                    .frame(minSize: 44.0)
+                    .contentShape(.rect)
             }
                 .accessibilityElement()
                 .accessibility(label: makeFavoriteButtonAccessibilityLabel(for: book))

--- a/Worm/Sources/Screens/Cell/BookListCell.swift
+++ b/Worm/Sources/Screens/Cell/BookListCell.swift
@@ -31,6 +31,7 @@ struct BookListCell: View {
             }
                 .accessibilityElement()
                 .accessibility(label: makeCellAccessibilityLabel(for: book))
+                .accessibilityAddTraits(.isButton)
             Spacer()
             Button { viewModel.toggleFavoriteStateOfBook(withID: book.id) } label: {
                 Image(systemName: (book.favorite

--- a/Worm/Sources/Screens/Main/MainScreen.swift
+++ b/Worm/Sources/Screens/Main/MainScreen.swift
@@ -8,8 +8,6 @@
 
 import SwiftUI
 
-// TODO: Accessibility.
-
 /// The main screen visual representation.
 struct MainScreen<
     FavoritesView: View,

--- a/Worm/Sources/Screens/OnboardingView.swift
+++ b/Worm/Sources/Screens/OnboardingView.swift
@@ -17,7 +17,14 @@ struct OnboardingView: View {
     var body: some View {
         VStack(alignment: .trailing) {
             Image(systemName: "xmark")
-                .padding([.vertical, .trailing], 4.0)
+                .accessibilityHidden(true)
+                .padding(
+                    [
+                        .vertical,
+                        .trailing
+                    ],
+                    4.0
+                )
             Text(text, comment: localizationComment)
         }
             .fontWeight(.light)

--- a/Worm/Sources/Screens/Recommendations/Filters/FiltersView.swift
+++ b/Worm/Sources/Screens/Recommendations/Filters/FiltersView.swift
@@ -25,33 +25,14 @@ struct FiltersView<ViewModel: FiltersViewModel>: View {
 #endif
         LazyVGrid(columns: [GridItem(.adaptive(minimum: 100.0))], spacing: 20.0) {
             ForEach(RecommendationsFilter.allCases, id: \.self) { filterItem in
-                let identifier = switch filterItem {
-                    case .topRated:
-                        "TopRatedFilterButton"
+                if viewModel.appliedFilters.contains(filterItem) {
+                    filterButton(for: filterItem)
+                        .buttonStyle(.borderedProminent)
+                        .accessibilityAddTraits(.isSelected)
+                } else {
+                    filterButton(for: filterItem)
+                        .buttonStyle(.bordered)
                 }
-                Button {
-                    withAnimation {
-                        if viewModel.appliedFilters.contains(filterItem) {
-                            viewModel.appliedFilters.removeAll { $0 == filterItem }
-                        } else {
-                            viewModel.appliedFilters.append(filterItem)
-                        }
-                    }
-                } label: {
-                    switch filterItem {
-                        case .topRated:
-                            Text("Top rated", comment: "A title for the Top Rated filter")
-                    }
-                }
-                    .accessibilityIdentifier(identifier)
-                    .`if`(viewModel.appliedFilters.contains(filterItem)) {
-                        $0
-                            .buttonStyle(.borderedProminent)
-                    } `else`: {
-                        $0
-                            .buttonStyle(.bordered)
-                    }
-                    .buttonBorderShape(.capsule)
             }
         }
             .padding(32.0)
@@ -82,6 +63,33 @@ struct FiltersView<ViewModel: FiltersViewModel>: View {
     /// - Parameter viewModel: Object responsible for the presentation logic of the recommendations filters.
     init(viewModel: ViewModel) {
         self.viewModel = viewModel
+    }
+
+    // MARK: - Methods
+
+    // MARK: Private methods
+
+    private func filterButton(for filterItem: RecommendationsFilter) -> some View {
+        let identifier = switch filterItem {
+            case .topRated:
+                "TopRatedFilterButton"
+        }
+        return Button {
+            withAnimation {
+                if viewModel.appliedFilters.contains(filterItem) {
+                    viewModel.appliedFilters.removeAll { $0 == filterItem }
+                } else {
+                    viewModel.appliedFilters.append(filterItem)
+                }
+            }
+        } label: {
+            switch filterItem {
+                case .topRated:
+                    Text("Top rated", comment: "A title for the Top Rated filter")
+            }
+        }
+            .buttonBorderShape(.capsule)
+            .accessibilityIdentifier(identifier)
     }
 
     // MARK: -

--- a/Worm/Sources/Screens/Recommendations/RecommendationsView.swift
+++ b/Worm/Sources/Screens/Recommendations/RecommendationsView.swift
@@ -39,15 +39,17 @@ struct RecommendationsView<ViewModel: RecommendationsViewModel>: View {
                         .listStyle(.plain)
                     if !viewModel.onboardingShown {
                         VStack {
-                            OnboardingView(
-                                text: "Recommendations are shown in the order of their relevance and update as you turn some of them down or mark more books as favorites.",
-                                localizationComment: "A tooltip that appears on the first launch of the app, explaining how recommendations work",
-                                color: .search
-                            )
+                            Button { viewModel.onboardingShown = true } label: {
+                                OnboardingView(
+                                    text: "Recommendations are shown in the order of their relevance and update as you turn some of them down or mark more books as favorites.",
+                                    localizationComment: "A tooltip that appears on the first launch of the app, explaining how recommendations work",
+                                    color: .search
+                                )
+                            }
+                                .buttonStyle(.plain)
                                 .accessibilityIdentifier("OnboardingLabel")
                             Spacer()
                         }
-                            .onTapGesture { viewModel.onboardingShown = true }
                     }
                 }
                     .animation(.default, value: viewModel.onboardingShown)

--- a/Worm/Sources/Screens/Recommendations/RecommendationsView.swift
+++ b/Worm/Sources/Screens/Recommendations/RecommendationsView.swift
@@ -81,6 +81,7 @@ struct RecommendationsView<ViewModel: RecommendationsViewModel>: View {
                         Image(systemName: "line.3.horizontal.decrease")
                     }
                         .accessibilityIdentifier("RecommendationsFiltersButton")
+                        .accessibilityLabel("Filters")
                         .accessibilityHint("Open recommendations filters.")
                 }
             }

--- a/Worm/Sources/Screens/Search/SearchView.swift
+++ b/Worm/Sources/Screens/Search/SearchView.swift
@@ -28,28 +28,32 @@ struct SearchView<ViewModel: SearchViewModel>: View {
                     .listStyle(.plain)
                 if !viewModel.searchOnboardingShown {
                     VStack {
-                        OnboardingView(
-                            text: "Start by searching your favorite books and marking them as favorites.",
-                            localizationComment: "A tooltip that appears on the first launch of the app, explaining how to use search",
-                            color: .favorites
-                        )
+                        Button { viewModel.searchOnboardingShown = true } label: {
+                            OnboardingView(
+                                text: "Start by searching your favorite books and marking them as favorites.",
+                                localizationComment: "A tooltip that appears on the first launch of the app, explaining how to use search",
+                                color: .favorites
+                            )
+                        }
+                            .buttonStyle(.plain)
                             .accessibilityIdentifier("SearchOnboardingLabel")
                         Spacer()
                     }
-                        .onTapGesture { viewModel.searchOnboardingShown = true }
                 }
                 if viewModel.searchOnboardingShown
                         && !viewModel.recommendationsOnboardingShown {
                     VStack {
                         Spacer()
-                        OnboardingView(
-                            text: "Then check your recommendations!",
-                            localizationComment: "A tooltip that appears on the first launch of the app, explaining how to check recommendations",
-                            color: .recommendations
-                        )
+                        Button { viewModel.recommendationsOnboardingShown = true } label: {
+                            OnboardingView(
+                                text: "Then check your recommendations!",
+                                localizationComment: "A tooltip that appears on the first launch of the app, explaining how to check recommendations",
+                                color: .recommendations
+                            )
+                        }
+                            .buttonStyle(.plain)
                             .accessibilityIdentifier("RecommendationsOnboardingLabel")
                     }
-                        .onTapGesture { viewModel.recommendationsOnboardingShown = true }
                 }
             }
                 .animation(.default, value: viewModel.searchOnboardingShown)

--- a/WormUITests/Tests/DetailsScreenTests.swift
+++ b/WormUITests/Tests/DetailsScreenTests.swift
@@ -57,12 +57,12 @@ final class BookDetailsViewUITests: XCTestCase {
         let app = XCTestCase.makeTestApp()
         app.launch()
 
-        let onboardingLabel = app.staticTexts["SearchOnboardingLabel"]
+        let onboardingLabel = app.buttons["SearchOnboardingLabel"]
         if onboardingLabel.waitForExistence(timeout: 0.1) {
             onboardingLabel.tap()
         }
 
-        let recommendationsOnboardingLabel = app.staticTexts["RecommendationsOnboardingLabel"]
+        let recommendationsOnboardingLabel = app.buttons["RecommendationsOnboardingLabel"]
         if recommendationsOnboardingLabel.waitForExistence(timeout: 0.1) {
             recommendationsOnboardingLabel.tap()
         }

--- a/WormUITests/Tests/MainScreenTests.swift
+++ b/WormUITests/Tests/MainScreenTests.swift
@@ -52,12 +52,12 @@ final class MainScreenTests: XCTestCase {
         let app = XCTestCase.makeTestApp()
         app.launch()
 
-        let searchOnboardingLabel = app.staticTexts["SearchOnboardingLabel"]
+        let searchOnboardingLabel = app.buttons["SearchOnboardingLabel"]
         if searchOnboardingLabel.waitForExistence(timeout: 0.1) {
             searchOnboardingLabel.tap()
         }
 
-        let recommendationsOnboardingLabel = app.staticTexts["RecommendationsOnboardingLabel"]
+        let recommendationsOnboardingLabel = app.buttons["RecommendationsOnboardingLabel"]
         if recommendationsOnboardingLabel.waitForExistence(timeout: 0.1) {
             recommendationsOnboardingLabel.tap()
         }

--- a/WormUITests/Tests/RecommendationsScreenTests.swift
+++ b/WormUITests/Tests/RecommendationsScreenTests.swift
@@ -21,7 +21,7 @@ final class RecommendationsScreenTests: XCTestCase {
     func testOnboarding_shown_onFirstLaunch() {
         let app = makeOpenRecommendationsTab(resetOnboarding: true)
 
-        let onboardingLabel = app.staticTexts["OnboardingLabel"]
+        let onboardingLabel = app.buttons["OnboardingLabel"]
         guard onboardingLabel.waitForExistence(timeout: 5.0) else {
             XCTFail("Onboarding didn't appear.")
             return
@@ -34,7 +34,7 @@ final class RecommendationsScreenTests: XCTestCase {
     func testOnboarding_disappears_onTap() {
         let app = makeOpenRecommendationsTab(resetOnboarding: true)
 
-        let onboardingLabel = app.staticTexts["OnboardingLabel"]
+        let onboardingLabel = app.buttons["OnboardingLabel"]
         guard onboardingLabel.waitForExistence(timeout: 5.0) else {
             XCTFail("Onboarding didn't appear.")
             return
@@ -51,7 +51,7 @@ final class RecommendationsScreenTests: XCTestCase {
     func testOnboarding_notShownTwice_afterDismissal() {
         let app = makeOpenRecommendationsTab(resetOnboarding: true)
 
-        let onboardingLabel = app.staticTexts["OnboardingLabel"]
+        let onboardingLabel = app.buttons["OnboardingLabel"]
         guard onboardingLabel.waitForExistence(timeout: 5.0) else {
             XCTFail("Onboarding didn't appear.")
             return

--- a/WormUITests/Tests/SearchScreenTests.swift
+++ b/WormUITests/Tests/SearchScreenTests.swift
@@ -17,7 +17,7 @@ final class SearchScreenTests: XCTestCase {
         let app = XCTestCase.makeTestApp(resetOnboarding: true)
         app.launch()
 
-        let onboardingLabel = app.staticTexts["SearchOnboardingLabel"]
+        let onboardingLabel = app.buttons["SearchOnboardingLabel"]
         guard onboardingLabel.waitForExistence(timeout: 5.0) else {
             XCTFail("Search onboarding didn't appear.")
             return
@@ -31,7 +31,7 @@ final class SearchScreenTests: XCTestCase {
         let app = XCTestCase.makeTestApp(resetOnboarding: true)
         app.launch()
 
-        let onboardingLabel = app.staticTexts["SearchOnboardingLabel"]
+        let onboardingLabel = app.buttons["SearchOnboardingLabel"]
         guard onboardingLabel.waitForExistence(timeout: 5.0) else {
             XCTFail("Search onboarding didn't appear.")
             return
@@ -49,7 +49,7 @@ final class SearchScreenTests: XCTestCase {
         let app = XCTestCase.makeTestApp(resetOnboarding: true)
         app.launch()
 
-        let onboardingLabel = app.staticTexts["SearchOnboardingLabel"]
+        let onboardingLabel = app.buttons["SearchOnboardingLabel"]
         guard onboardingLabel.waitForExistence(timeout: 5.0) else {
             XCTFail("Search onboarding didn't appear.")
             return
@@ -74,7 +74,7 @@ final class SearchScreenTests: XCTestCase {
         let app = XCTestCase.makeTestApp(resetOnboarding: true)
         app.launch()
 
-        let searchOnboardingLabel = app.staticTexts["SearchOnboardingLabel"]
+        let searchOnboardingLabel = app.buttons["SearchOnboardingLabel"]
         guard searchOnboardingLabel.waitForExistence(timeout: 5.0) else {
             XCTFail("Search onboarding didn't appear.")
             return
@@ -86,7 +86,7 @@ final class SearchScreenTests: XCTestCase {
             return
         }
 
-        let recommendationsOnboardingLabel = app.staticTexts["RecommendationsOnboardingLabel"]
+        let recommendationsOnboardingLabel = app.buttons["RecommendationsOnboardingLabel"]
         guard recommendationsOnboardingLabel.waitForExistence(timeout: 5.0) else {
             XCTFail("Search onboarding didn't appear.")
             return
@@ -100,14 +100,14 @@ final class SearchScreenTests: XCTestCase {
         let app = XCTestCase.makeTestApp(resetOnboarding: true)
         app.launch()
 
-        let searchOnboardingLabel = app.staticTexts["SearchOnboardingLabel"]
+        let searchOnboardingLabel = app.buttons["SearchOnboardingLabel"]
         guard searchOnboardingLabel.waitForExistence(timeout: 5.0) else {
             XCTFail("Search onboarding didn't appear.")
             return
         }
         searchOnboardingLabel.tap()
 
-        let recommendationsOnboardingLabel = app.staticTexts["RecommendationsOnboardingLabel"]
+        let recommendationsOnboardingLabel = app.buttons["RecommendationsOnboardingLabel"]
         guard recommendationsOnboardingLabel.waitForExistence(timeout: 5.0) else {
             XCTFail("Search onboarding didn't appear.")
             return
@@ -127,14 +127,14 @@ final class SearchScreenTests: XCTestCase {
         let app = XCTestCase.makeTestApp(resetOnboarding: true)
         app.launch()
 
-        let searchOnboardingLabel = app.staticTexts["SearchOnboardingLabel"]
+        let searchOnboardingLabel = app.buttons["SearchOnboardingLabel"]
         guard searchOnboardingLabel.waitForExistence(timeout: 5.0) else {
             XCTFail("Search onboarding didn't appear.")
             return
         }
         searchOnboardingLabel.tap()
 
-        let recommendationsOnboardingLabel = app.staticTexts["RecommendationsOnboardingLabel"]
+        let recommendationsOnboardingLabel = app.buttons["RecommendationsOnboardingLabel"]
         guard recommendationsOnboardingLabel.waitForExistence(timeout: 5.0) else {
             XCTFail("Search onboarding didn't appear.")
             return


### PR DESCRIPTION
## Summary

1. **Onboarding tooltips unreachable by VoiceOver** – replaced `onTapGesture`-based dismissal with real `Button`s in `SearchView`/`RecommendationsView`, so they get the `.isButton` trait and default VoiceOver activation for free. (Required updating 4 UI test files that queried these elements via `app.staticTexts[...]` to `app.buttons[...]`, matching the new accessibility tree.)
2. **Onboarding close icon had no accessible meaning** – the `xmark` icon now hidden from VoiceOver (`.accessibilityHidden(true)`), since dismissal is handled by the enclosing `Button` from fix #1.
3. **Filters toolbar button had a hint but no label** – added `.accessibilityLabel("Filters")` (with en/ru translations), so VoiceOver announces a clean label instead of the SF Symbol's raw auto-generated name.
4. **Filter selection state wasn't conveyed accessibly** – added `.isSelected` trait when a filter is applied. Along the way, removed the `View.if(_:transform:else:)` custom modifier per review feedback (avoids the SwiftUI ternary-on-different-concrete-ButtonStyle-types trap), replacing it with a plain `if`/`else` and an extracted `filterButton(for:)` helper in `FiltersView`.
5. **Book list row's tappable info portion didn't announce as actionable** – added `.accessibilityAddTraits(.isButton)` to the author/title accessibility element in `BookListCell`.
6. **Favourite-toggle button's tap target was below the 44x44pt HIG minimum** – grew it via a new `View.frame(minSize:)` convenience + `.contentShape(.rect)`, without changing the icon's visual size.
7. **Stale `// TODO: Accessibility.` in `MainScreen.swift`** – removed; the real issues lived in child views and are now fixed.

## Test plan

- [x] `xcodebuild build` succeeds
- [x] Full `WormTests` suite passes (106/106)
- [x] Full `WormUITests` suite passes (27/27), including the onboarding dismiss and filter-toggle interactions affected by these changes