### PR TITLE
Add BlockedBooksModel/BlockedBooksViewModel for the Blocked screen

### DIFF
--- a/Worm/Sources/Screens/Blocked/BlockedBooksModel.swift
+++ b/Worm/Sources/Screens/Blocked/BlockedBooksModel.swift
@@ -1,0 +1,97 @@
+//
+//  BlockedBooksModel.swift
+//  Worm
+//
+//  Created by Nikita Lazarev-Zubov on 9.8.2026.
+//  Copyright © 2026 Nikita Lazarev-Zubov. All rights reserved.
+//
+
+import Combine
+import GoodreadsService
+
+/// Owns logic of maintaining a list of blocked books.
+protocol BlockedBooksModel: Actor {
+
+    // MARK: - Properties
+
+    /// The list of blocked books.
+    var blockedBooks: [Book] { get }
+    /// The publisher of changes to the list of blocked books.
+    var blockedBooksPublisher: Published<[Book]>.Publisher { get }
+
+    // MARK: - Methods
+
+    /// Removes a book from the blocked list.
+    /// - Parameter id: The ID of the book to manipulate.
+    /// - Throws: An error if the change couldn't be persisted.
+    func unblockBook(withID id: String) async throws
+
+}
+
+// MARK: -
+
+/// The default logic of the blocked books list maintenance.
+actor BlockedBooksServiceBasedModel: BlockedBooksModel {
+
+    // MARK: - Properties
+
+    // MARK: BlockedBooksModel protocol properties
+
+    var blockedBooksPublisher: Published<[Book]>.Publisher { $blockedBooks }
+    @Published
+    private(set) var blockedBooks = [Book]()
+
+    // MARK: Private properties
+
+    private let blockedBooksService: any BlockedBooksService
+    private let catalogService: CatalogService
+    private lazy var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Initialization
+
+    /// Creates a blocked books list handler.
+    /// - Parameters:
+    ///   - catalogService: The data service of the app.
+    ///   - blockedBooksService: The blocked books list manager.
+    init(catalogService: CatalogService, blockedBooksService: any BlockedBooksService) {
+        self.catalogService = catalogService
+        self.blockedBooksService = blockedBooksService
+
+        Task { [weak self] in
+            await self?.bindBlockedBooksService(blockedBooksService)
+        }
+    }
+
+    // MARK: - Methods
+
+    // MARK: BlockedBooksModel protocol methods
+
+    func unblockBook(withID id: String) async throws {
+        try await blockedBooksService.removeFromBlockedBook(withID: id)
+    }
+
+    // MARK: Private methods
+
+    private func bindBlockedBooksService(_ blockedBooksService: any BlockedBooksService) async {
+        await blockedBooksService
+            .blockedBookIDsPublisher
+            .removeDuplicates()
+            .sink { @Sendable ids in
+                Task { [weak self] in
+                    await self?.updateBlocked(with: ids)
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    private func updateBlocked(with blockedBookIDs: Set<String>) async {
+        blockedBooks.removeAll { !blockedBookIDs.contains($0.id) }
+        for bookID in blockedBookIDs {
+            if let book = await catalogService.getBook(by: bookID),
+               !blockedBooks.contains(where: { $0.id == book.id }) {
+                blockedBooks.append(book)
+            }
+        }
+    }
+
+}

--- a/Worm/Sources/Screens/Blocked/BlockedBooksViewModel.swift
+++ b/Worm/Sources/Screens/Blocked/BlockedBooksViewModel.swift
@@ -1,0 +1,131 @@
+//
+//  BlockedBooksViewModel.swift
+//  Worm
+//
+//  Created by Nikita Lazarev-Zubov on 9.8.2026.
+//  Copyright © 2026 Nikita Lazarev-Zubov. All rights reserved.
+//
+
+import Combine
+
+/// Object responsible for the Blocked screen presentation logic.
+@MainActor
+protocol BlockedBooksViewModel: BookDetailsPresentable, ObservableObject {
+
+    // MARK: - Properties
+
+    /// A list of view models representing items on the Blocked screen.
+    var blockedBooks: [BookViewModel] { get }
+    /// Whether an error alert about a failed save should be shown.
+    var errorDisplayed: Bool { get set }
+
+    // MARK: - Methods
+
+    /// Removes a book from the blocked list.
+    /// - Parameter book: The book to unblock.
+    func unblockBook(_ book: BookViewModel)
+
+}
+
+// MARK: -
+
+/// The default implementation of the Blocked screen view model.
+final class BlockedBooksDefaultViewModel: BlockedBooksViewModel {
+
+    // MARK: - Properties
+
+    // MARK: BlockedBooksViewModel protocol properties
+
+    @Published
+    private(set) var blockedBooks = [BookViewModel]()
+    @Published
+    var errorDisplayed = false
+
+    // MARK: Private properties
+
+    private let imageService: ImageService
+    private let model: any BlockedBooksModel
+    private lazy var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Initialization
+
+    /// Creates a view model object.
+    /// - Parameters:
+    ///   - model: Data providing object.
+    ///   - imageService: The services that turns image URLs into images themselves.
+    init(model: any BlockedBooksModel, imageService: ImageService) {
+        self.model = model
+        self.imageService = imageService
+
+        Task { [weak self] in
+            await self?.bind(model: model)
+        }
+    }
+
+    // MARK: - Methods
+
+    // MARK: BlockedBooksViewModel protocol methods
+
+    func unblockBook(_ book: BookViewModel) {
+        Task { @MainActor [weak self] in
+            do {
+                try await self?.model.unblockBook(withID: book.id)
+            } catch {
+                self?.errorDisplayed = true
+            }
+        }
+    }
+
+    func makeDetailsViewModel(for book: BookViewModel) -> some BookDetailsViewModel {
+        BookDetailsDefaultViewModel(
+            authors: book.authors,
+            title: book.title,
+            description: book.description,
+            imageURL: book.imageURL,
+            rating: book.rating,
+            imageService: imageService
+        )
+    }
+
+    // MARK: Private methods
+
+    private func bind(model: any BlockedBooksModel) async {
+        await model
+            .blockedBooksPublisher
+            .removeDuplicates()
+            .sink { @Sendable books in
+                Task { @MainActor [weak self] in
+                    self?.blockedBooks = books.map { BookViewModel(book: $0, favorite: false) }
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+}
+
+#if DEBUG
+import GoodreadsService
+
+final class BlockedBooksPreviewViewModel: BlockedBooksViewModel {
+
+    // MARK: - Properties
+
+    // MARK: BlockedBooksViewModel protocol properties
+
+    var blockedBooks = Book.previewFixtures.map { BookViewModel(book: $0, favorite: false) }
+    var errorDisplayed = false
+
+    // MARK: - Methods
+
+    // MARK: BlockedBooksViewModel protocol methods
+
+    func unblockBook(_ book: BookViewModel) {
+        blockedBooks.removeAll { $0.id == book.id }
+    }
+
+    func makeDetailsViewModel(for book: BookViewModel) -> some BookDetailsViewModel {
+        BookDetailsPreviewViewModel()
+    }
+
+}
+#endif

--- a/WormTests/Tests/Screens/Blocked/BlockedBooksDefaultViewModelTests.swift
+++ b/WormTests/Tests/Screens/Blocked/BlockedBooksDefaultViewModelTests.swift
@@ -1,0 +1,153 @@
+//
+//  BlockedBooksDefaultViewModelTests.swift
+//  WormTests
+//
+//  Created by Nikita Lazarev-Zubov on 9.8.2026.
+//
+
+import Combine
+import GoodreadsService
+import Testing
+@testable
+import Worm
+
+@MainActor
+struct BlockedBooksDefaultViewModelTests {
+
+    // MARK: - Methods
+
+    @Test
+    func blockedBooks_empty_initially() async {
+        let vm: any BlockedBooksViewModel = await BlockedBooksDefaultViewModel(
+            model: BlockedBooksMockModel(), imageService: ImageMockService()
+        )
+        #expect(vm.blockedBooks.isEmpty, "Blocked list is not empty initially.")
+    }
+
+    @Test
+    func detailsViewModel_authors_asExpected() async {
+        let vm: any BlockedBooksViewModel = await BlockedBooksDefaultViewModel(
+            model: BlockedBooksMockModel(), imageService: ImageMockService()
+        )
+
+        let bookVM = BookViewModel(
+            book: Book(
+                id: "ID",
+                authors: [
+                    "Author1",
+                    "Author2"
+                ],
+                title: "Title",
+                description: "Desc"
+            ),
+            favorite: false
+        )
+        let bookDetailsVM = vm.makeDetailsViewModel(for: bookVM)
+
+        #expect(bookDetailsVM.authors == bookVM.authors, "Unexpected authors string generated")
+    }
+
+    @Test
+    func detailsViewModel_title_asExpected() async {
+        let vm: any BlockedBooksViewModel = await BlockedBooksDefaultViewModel(
+            model: BlockedBooksMockModel(), imageService: ImageMockService()
+        )
+
+        let bookVM = BookViewModel(
+            book: Book(
+                id: "ID",
+                authors: [
+                    "Author1",
+                    "Author2"
+                ],
+                title: "Title",
+                description: "Desc"
+            ),
+            favorite: false
+        )
+        let bookDetailsVM = vm.makeDetailsViewModel(for: bookVM)
+
+        #expect(bookDetailsVM.title == bookVM.title, "Unexpected authors string generated")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func blockedBooks_update_works() async {
+        let id = "1"
+        let book = Book(id: id, authors: [], title: "", description: "Desc")
+
+        let vm: any BlockedBooksViewModel = await BlockedBooksDefaultViewModel(
+            model: BlockedBooksMockModel(blocked: [book]), imageService: ImageMockService()
+        )
+        while vm.blockedBooks != [BookViewModel(book: book, favorite: false)] {
+            await Task.yield()
+        }
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func blockedBooks_update_onUnblocking() async {
+        let id = "1"
+        let book = Book(id: id, authors: [], title: "", description: "Desc")
+
+        let vm: any BlockedBooksViewModel = await BlockedBooksDefaultViewModel(
+            model: BlockedBooksMockModel(blocked: [book]), imageService: ImageMockService()
+        )
+        while vm.blockedBooks.isEmpty {
+            await Task.yield()
+        }
+
+        vm.unblockBook(BookViewModel(book: book, favorite: false))
+        while !vm.blockedBooks.isEmpty {
+            await Task.yield()
+        }
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func errorDisplayed_set_whenUnblockingFails() async {
+        let book = Book(id: "1", authors: [], title: "", description: "Desc")
+        let vm: any BlockedBooksViewModel = await BlockedBooksDefaultViewModel(
+            model: BlockedBooksMockModel(blocked: [book], errorToThrow: MockError()), imageService: ImageMockService()
+        )
+
+        vm.unblockBook(BookViewModel(book: book, favorite: false))
+        while !vm.errorDisplayed {
+            await Task.yield()
+        }
+    }
+
+    // MARK: -
+
+    private actor BlockedBooksMockModel: BlockedBooksModel {
+
+        // MARK: - Properties
+
+        // MARK: BlockedBooksModel protocol properties
+
+        var blockedBooksPublisher: Published<[Book]>.Publisher { $blockedBooks }
+        @Published
+        private(set) var blockedBooks: [Book]
+
+        // MARK: Private properties
+
+        private let errorToThrow: Error?
+
+        // MARK: - Initialization
+
+        init(blocked: [Book] = [], errorToThrow: Error? = nil) async {
+            self.blockedBooks = blocked
+            self.errorToThrow = errorToThrow
+        }
+
+        // MARK: - Methods
+
+        // MARK: BlockedBooksModel protocol methods
+
+        func unblockBook(withID id: String) throws {
+            if let errorToThrow {
+                throw errorToThrow
+            }
+            blockedBooks.removeAll { $0.id == id }
+        }
+
+    }
+
+}

--- a/WormTests/Tests/Screens/Blocked/BlockedBooksServiceBasedModelTests.swift
+++ b/WormTests/Tests/Screens/Blocked/BlockedBooksServiceBasedModelTests.swift
@@ -1,0 +1,68 @@
+//
+//  BlockedBooksServiceBasedModelTests.swift
+//  WormTests
+//
+//  Created by Nikita Lazarev-Zubov on 9.8.2026.
+//
+
+import Combine
+import GoodreadsService
+import Testing
+@testable
+import Worm
+
+struct BlockedBooksServiceBasedModelTests {
+
+    // MARK: - Methods
+
+    @Test
+    func blocked_empty_initially() async {
+        let model: BlockedBooksModel = await BlockedBooksServiceBasedModel(
+            catalogService: CatalogMockService(), blockedBooksService: BlockedBooksMockService()
+        )
+        await #expect(model.blockedBooks.isEmpty, "Blocked list is not empty initially.")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func blocked_update() async {
+        let id = "1"
+        let book = Book(id: id, authors: [], title: "", description: "Desc")
+
+        let model: BlockedBooksModel = await BlockedBooksServiceBasedModel(
+            catalogService: CatalogMockService(books: [book]),
+            blockedBooksService: BlockedBooksMockService(blockedBookIDs: [id])
+        )
+        while await model.blockedBooks != [book] {
+            await Task.yield()
+        }
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func blocked_update_onUnblocking() async throws {
+        let id = "1"
+        let book = Book(id: id, authors: [], title: "", description: "Desc")
+
+        let model: BlockedBooksModel = await BlockedBooksServiceBasedModel(
+            catalogService: CatalogMockService(books: [book]),
+            blockedBooksService: BlockedBooksMockService(blockedBookIDs: [id])
+        )
+        while await model.blockedBooks != [book] {
+            await Task.yield()
+        }
+
+        try await model.unblockBook(withID: id)
+        while await !model.blockedBooks.isEmpty {
+            await Task.yield()
+        }
+    }
+
+    @Test
+    func unblockBook_throws_whenServiceFails() async {
+        let model: BlockedBooksModel = await BlockedBooksServiceBasedModel(
+            catalogService: CatalogMockService(),
+            blockedBooksService: BlockedBooksMockService(errorToThrow: MockError())
+        )
+        await #expect(throws: MockError.self) { try await model.unblockBook(withID: "1") }
+    }
+
+}


### PR DESCRIPTION
## Summary

- PR 2a of the Blocked-tab feature (part D of the TODO cleanup pass): adds `BlockedBooksModel`/`BlockedServiceBasedModel` and `BlockedBooksViewModel`/`BlockedBooksDefaultViewModel`, mirroring `RecommendationsModel`'s service-binding pattern.
- Deliberately omits favourite-tracking: a blocked book is a recommended book hidden from recommendations, and favourites can't be recommended, so a blocked book can never be a favourite – the indication would be meaningless.
- Unit tests for both the model and view model, including error-on-unblock-failure and reactive update paths.

## Test plan

- [x] `xcodebuild build` — no warnings
- [x] Full `WormTests` suite — 120/120 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)