### PR TITLE
Match tab bar buttons by accessibility identifier in UI tests

### DIFF
--- a/WormUITests/Tests/BlockedScreenTests.swift
+++ b/WormUITests/Tests/BlockedScreenTests.swift
@@ -19,7 +19,7 @@ final class BlockedScreenTests: XCTestCase {
 
         dismissOnboarding(in: app)
 
-        app.tabBars.buttons["Blocked"].tap()
+        app.tabBars.buttons["BlockedTabButton"].tap()
 
         XCTAssertTrue(app.tables.staticTexts.count == 0)
     }
@@ -32,7 +32,7 @@ final class BlockedScreenTests: XCTestCase {
 
         favoriteBook(titled: "The Lord of the Rings", in: app)
 
-        app.tabBars.buttons["Recommendations"].tap()
+        app.tabBars.buttons["RecommendationsTabButton"].tap()
 
         let recommendedBook = app.staticTexts["The Wind-Up Bird Chronicle"]
         guard recommendedBook.waitForExistence(timeout: 5.0) else {
@@ -42,7 +42,7 @@ final class BlockedScreenTests: XCTestCase {
         recommendedBook.swipeLeft()
 
         app.buttons["Delete"].tap()
-        app.tabBars.buttons["Blocked"].tap()
+        app.tabBars.buttons["BlockedTabButton"].tap()
 
         let blockedBook = app.staticTexts["The Wind-Up Bird Chronicle"]
         guard blockedBook.waitForExistence(timeout: 5.0) else {
@@ -58,7 +58,7 @@ final class BlockedScreenTests: XCTestCase {
             return
         }
 
-        app.tabBars.buttons["Recommendations"].tap()
+        app.tabBars.buttons["RecommendationsTabButton"].tap()
         XCTAssertTrue(
             app.staticTexts["The Wind-Up Bird Chronicle"].waitForExistence(timeout: 5.0),
             "Book didn't reappear as a recommendation after unblocking."

--- a/WormUITests/Tests/MainScreenTests.swift
+++ b/WormUITests/Tests/MainScreenTests.swift
@@ -14,7 +14,7 @@ final class MainScreenTests: XCTestCase {
 
     func testSearchTab_visible() {
         let app = launchedApp()
-        XCTAssertTrue(app.tabBars.buttons["Search"].isHittable)
+        XCTAssertTrue(app.tabBars.buttons["SearchTabButton"].isHittable)
     }
 
     func testSearchTab_selectedByDefault() {
@@ -24,36 +24,36 @@ final class MainScreenTests: XCTestCase {
 
     func testRecommendationsTab_visible() {
         let app = launchedApp()
-        XCTAssertTrue(app.tabBars.buttons["Recommendations"].isHittable)
+        XCTAssertTrue(app.tabBars.buttons["RecommendationsTabButton"].isHittable)
     }
 
     func testTappingRecommendationsTab_showsRecommendationsScreen() {
         let app = launchedApp()
-        app.tabBars.buttons["Recommendations"].tap()
+        app.tabBars.buttons["RecommendationsTabButton"].tap()
 
         XCTAssertTrue(app.staticTexts["Recommendations"].exists)
     }
 
     func testFavoritesTab_visible() {
         let app = launchedApp()
-        XCTAssertTrue(app.tabBars.buttons["Favorites"].isHittable)
+        XCTAssertTrue(app.tabBars.buttons["FavoritesTabButton"].isHittable)
     }
 
     func testTappingFavoritesTab_showsFavoritesScreen() {
         let app = launchedApp()
-        app.tabBars.buttons["Favorites"].tap()
+        app.tabBars.buttons["FavoritesTabButton"].tap()
 
         XCTAssertTrue(app.staticTexts["Favorites"].exists)
     }
 
     func testBlockedTab_visible() {
         let app = launchedApp()
-        XCTAssertTrue(app.tabBars.buttons["Blocked"].isHittable)
+        XCTAssertTrue(app.tabBars.buttons["BlockedTabButton"].isHittable)
     }
 
     func testTappingBlockedTab_showsBlockedScreen() {
         let app = launchedApp()
-        app.tabBars.buttons["Blocked"].tap()
+        app.tabBars.buttons["BlockedTabButton"].tap()
 
         XCTAssertTrue(app.staticTexts["Blocked"].exists)
     }


### PR DESCRIPTION
## Summary

- `MainScreenTests.swift` and `BlockedScreenTests.swift` were matching tab bar buttons by their localised label text (e.g. `app.tabBars.buttons["Blocked"]`), rather than the accessibility identifiers (`SearchTabButton`, `RecommendationsTabButton`, `FavoritesTabButton`, `BlockedTabButton`) added to `MainScreen` during the accessibility-audit pass.
- Switched both files over to the identifiers, matching the convention already used elsewhere in the suite (e.g., `RecommendationsScreenTests.swift`).
- `staticTexts[...]` checks that verify the loaded screen's title are left as-is – those confirm screen content, not tab identity, and there's no identifier to swap them for.

## Test plan

- [x] `xcodebuild build` – no warnings
- [x] `MainScreenTests` + `BlockedScreenTests` – 10/10 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)