### PR TITLE
Dismiss the search field's keyboard on tapping anywhere else

### DIFF
--- a/Worm/Sources/Screens/Main/MainScreen.swift
+++ b/Worm/Sources/Screens/Main/MainScreen.swift
@@ -25,9 +25,13 @@ struct MainScreen<
         TabView {
             NavigationStack {
                 searchView
-                    .searchable(text: $viewModel.query, prompt: "Search books")
-                    .autocorrectionDisabled(true)
+                    // Makes the whole content area participate in hit testing, including otherwise empty areas.
+                    .contentShape(Rectangle())
+                    .simultaneousGesture(TapGesture().onEnded { searchFieldFocused = false }, including: .all)
                     .navigationTitle("Search")
+                    .searchable(text: $viewModel.query, prompt: "Search books")
+                    .searchFocused($searchFieldFocused)
+                    .autocorrectionDisabled(true)
             }
                 .tabItem {
                     Label("Search", systemImage: "magnifyingglass")
@@ -66,6 +70,8 @@ struct MainScreen<
     private let favoritesView: FavoritesView
     private let recommendationsView: RecommendationsView
     private let searchView: SearchView
+    @FocusState
+    private var searchFieldFocused: Bool
     @ObservedObject
     private var viewModel: ViewModel
 


### PR DESCRIPTION
## Summary

- With `.searchable` active on the Search tab, tapping a result cell, the favorite button, or empty space while the field had text previously left the keyboard up (only clearing the text or tapping Cancel dismissed it).
- `.searchable` is declared in `MainScreen`, not `SearchView`, so the `@FocusState`/dismissal gesture needed to live there too – with `.searchFocused` applied *after* `.searchable` so it binds to the same search field instance, and the tap gesture applied *before* `.searchable` as a `.simultaneousGesture` so it doesn't steal taps from the List/Buttons underneath.

## Test plan

- [x] Manually verified: tapping a result row, the favourite heart, and empty space all now dismiss the keyboard while preserving their own tap behaviour (opening details, toggling favorite).
- [x] Build succeeds.