### PR TITLE
Batch the favourite-flag rebuild into a single books update

### DIFF
--- a/Worm/Sources/Screens/Search/SearchViewModel.swift
+++ b/Worm/Sources/Screens/Search/SearchViewModel.swift
@@ -126,15 +126,15 @@ final class SearchDefaultViewModel: MainScreenViewModel, SearchViewModel {
                     guard let self else {
                         return
                     }
-                    for bookIndex in books.indices {
-                        books[bookIndex] = BookViewModel(
-                            id: books[bookIndex].id,
-                            authors: books[bookIndex].authors,
-                            title: books[bookIndex].title,
-                            description: books[bookIndex].description,
-                            imageURL: books[bookIndex].imageURL,
-                            rating: books[bookIndex].rating,
-                            favorite: ids.contains(books[bookIndex].id)
+                    books = books.map {
+                        BookViewModel(
+                            id: $0.id,
+                            authors: $0.authors,
+                            title: $0.title,
+                            description: $0.description,
+                            imageURL: $0.imageURL,
+                            rating: $0.rating,
+                            favorite: ids.contains($0.id)
                         )
                     }
                 }


### PR DESCRIPTION
## Summary

- Toggling a favorite in Search caused the whole list to visibly flash: `favoriteBookIDsPublisher`'s sink mutated `books[bookIndex]` in a loop, one `@Published` publish per row instead of one for the whole change.
- Rebuild the array with `.map` and assign it once, so the list republishes/re-renders exactly once per toggle.

## Test plan

- [x] Build succeeds.
- [x] Manual: toggle a favourite in Search results and confirm the list no longer flashes.